### PR TITLE
Fix reactive body color in Card component

### DIFF
--- a/src/lib/Card.svelte
+++ b/src/lib/Card.svelte
@@ -57,8 +57,8 @@
 		}
 	}
 
-	// 背景色を取得
-	let bodyColor = getBodyColor(borderColor);
+        // 背景色を取得
+        $: bodyColor = getBodyColor(borderColor);
 </script>
 
 <div class="CardWrapper" style="--border-color: var({borderColor})">


### PR DESCRIPTION
## Summary
- make the card body color reactive in `Card.svelte`

## Testing
- `pnpm lint` *(fails: formatting issues)*
- `pnpm check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843130968748331b428a63bbf62c078