### PR TITLE
Add default footer story

### DIFF
--- a/src/stories/Footer.stories.ts
+++ b/src/stories/Footer.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Footer from '$lib/Footer.svelte';
-import { CCLVividColor, CCLPastelColor } from '$lib/const/config';
+import { CCLVividColor } from '$lib/const/config';
 import { expect } from '@storybook/test';
 import AllColorsFooterWrapper from './AllColors/AllColorsFooterWrapper.svelte';
 

--- a/src/stories/Footer.stories.ts
+++ b/src/stories/Footer.stories.ts
@@ -42,6 +42,8 @@ const createStory = (bgColor: string): Story => ({
 	}
 });
 
+export const Default = createStory(CCLVividColor.STRAWBERRY_PINK);
+
 export const AllColors: Story = {
 	render: () => ({ Component: AllColorsFooterWrapper }),
 	args: {},


### PR DESCRIPTION
## Summary
- show a single footer component in storybook

## Testing
- `pnpm lint` *(fails: code style issues in repo)*
- `pnpm test-sb` *(fails: Storybook instance not running)*
- `pnpm check` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_687de980d0e08331a6eaaac0ca2eb5cf