### PR TITLE
Fix interface placement for Carousel

### DIFF
--- a/src/lib/Carousel.svelte
+++ b/src/lib/Carousel.svelte
@@ -1,4 +1,9 @@
 <script context="module" lang="ts">
+	/**
+	 * 表示する画像のオブジェクト。｛src: string, alt: string｝を要素とした配列で指定
+	 * @type string src - Image URL
+	 * @type string alt - Text for alt attribute
+	 */
 	export interface Imgsrc {
 		src: string;
 		alt: string;

--- a/src/lib/Carousel.svelte
+++ b/src/lib/Carousel.svelte
@@ -1,15 +1,12 @@
-<script lang="ts">
-	import './const/variables.css';
-
-	/**
-	 * Interface for carousel image data
-	 * @type src - Image URL
-	 * @type alt - Text for alt attribute
-	 */
+<script context="module" lang="ts">
 	export interface Imgsrc {
 		src: string;
 		alt: string;
 	}
+</script>
+
+<script lang="ts">
+	import './const/variables.css';
 
 	/**
 	 * Image data

--- a/src/stories/Carousel.stories.ts
+++ b/src/stories/Carousel.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Carousel from '$lib/Carousel.svelte';
-import { CCLVividColor } from 'cclkit4svelte';
 
 const meta = {
 	title: 'CommonComponents/Carousel',


### PR DESCRIPTION
## Summary
- declare `Imgsrc` interface in module context for Carousel
- reference the interface from component script
- run `svelte-check` to verify the previous error is gone

## Testing
- `pnpm run check` *(fails: svelte-check found 71 errors and 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6888ff91fa508331ab2219a1ee2ef24b