### PR TITLE
[fix]Dialog SSR ガードと重複IDの解消

### DIFF
--- a/src/lib/Dialog.svelte
+++ b/src/lib/Dialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import { browser } from '$app/environment';
   import { CCLVividColor } from '$lib/const/config';
   type VividVar = (typeof CCLVividColor)[keyof typeof CCLVividColor];
 
@@ -33,6 +34,7 @@
   // ヘッダー背景は borderColor と共通化
   let panelEl: HTMLElement | null = null;
   let previouslyFocused: Element | null = null;
+  const titleId = `ccl-dialog-title-${Math.random().toString(36).substring(2, 9)}`;
 
   function close() {
     dispatch('close');
@@ -98,17 +100,19 @@
     return () => window.removeEventListener('keydown', handle, true);
   });
 
-  $: if (open) {
-    // 表示されたときに実施
-    setTimeout(moveFocusIn, 0);
-    if (!unlockScroll) unlockScroll = lockScroll();
-  } else {
-    // 非表示に切り替わったとき
-    if (unlockScroll) {
-      unlockScroll();
-      unlockScroll = null;
+  $: if (browser) {
+    if (open) {
+      // 表示されたときに実施
+      setTimeout(moveFocusIn, 0);
+      if (!unlockScroll) unlockScroll = lockScroll();
+    } else {
+      // 非表示に切り替わったとき
+      if (unlockScroll) {
+        unlockScroll();
+        unlockScroll = null;
+      }
+      restoreFocus();
     }
-    restoreFocus();
   }
 
   onDestroy(() => {
@@ -123,13 +127,13 @@
       class="ccl-dialog-panel"
       role="dialog"
       aria-modal="true"
-      aria-labelledby="ccl-dialog-title"
+      aria-labelledby={titleId}
       style="--border-color: var({borderColor});"
       on:click|stopPropagation
       tabindex="-1"
     >
       <header class="ccl-dialog-header">
-        <h2 id="ccl-dialog-title" class="ccl-dialog-title">
+        <h2 id={titleId} class="ccl-dialog-title">
           <slot name="title">{title}</slot>
         </h2>
         <button class="ccl-dialog-close" aria-label="Close dialog" on:click={close}>

--- a/src/lib/Dialog.svelte
+++ b/src/lib/Dialog.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
-  import { browser } from '$app/environment';
   import { CCLVividColor } from '$lib/const/config';
   type VividVar = (typeof CCLVividColor)[keyof typeof CCLVividColor];
+
+  const isBrowser = typeof window !== 'undefined';
 
   const dispatch = createEventDispatcher<{ close: void }>();
 
@@ -100,7 +101,7 @@
     return () => window.removeEventListener('keydown', handle, true);
   });
 
-  $: if (browser) {
+  $: if (isBrowser) {
     if (open) {
       // 表示されたときに実施
       setTimeout(moveFocusIn, 0);


### PR DESCRIPTION
## Summary
- fix SSR error by guarding DOM access with `browser`
- generate unique title id per dialog instance

## Testing
- `pnpm run check` *(fails: svelte-check found 111 errors and 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cfe158a88331b1195f4f033199ee