### PR TITLE
Implement PrismaticGradientButton

### DIFF
--- a/src/lib/PrismaticGradientButton.svelte
+++ b/src/lib/PrismaticGradientButton.svelte
@@ -1,0 +1,211 @@
+<script context="module" lang="ts">
+  export type PrismaticGradientButtonTone = 'primary' | 'secondary';
+  export type PrismaticGradientButtonSize = 'large' | 'medium';
+  export type PrismaticGradientButtonType = 'button' | 'submit' | 'reset';
+</script>
+
+<script lang="ts">
+  import { CCLPastelColor, CCLVividColor } from './const/config';
+  import type { ColorVar } from './const/config';
+
+  type GradientStops = {
+    primaryStart: ColorVar;
+    primaryEnd: ColorVar;
+    secondaryStart: ColorVar;
+    secondaryEnd: ColorVar;
+    disabledStart: ColorVar;
+    disabledEnd: ColorVar;
+  };
+
+  /**
+   * ボタン内に表示するラベル
+   * @default Explore the Lab
+   */
+  export let label: string = 'Explore the Lab';
+
+  /**
+   * ボタンの視覚的な強さ
+   * @default primary
+   */
+  export let tone: PrismaticGradientButtonTone = 'primary';
+
+  /**
+   * ボタンサイズ
+   * @default large
+   */
+  export let size: PrismaticGradientButtonSize = 'large';
+
+  /**
+   * グラデーションの基準色
+   * @default --strawberry-pink
+   */
+  export let color: ColorVar = CCLVividColor.STRAWBERRY_PINK;
+
+  /**
+   * ボタンの非活性状態
+   * @default false
+   */
+  export let disabled: boolean = false;
+
+  /**
+   * button要素のtype属性
+   * @default button
+   */
+  export let type: PrismaticGradientButtonType = 'button';
+
+  /**
+   * クリックイベントハンドラ
+   * @default () => {}
+   */
+  export let onClick: () => void = () => {};
+
+  const fallbackStops: GradientStops = {
+    primaryStart: CCLVividColor.STRAWBERRY_PINK,
+    primaryEnd: CCLVividColor.SODA_BLUE,
+    secondaryStart: CCLPastelColor.PEACH_PINK,
+    secondaryEnd: CCLVividColor.STRAWBERRY_PINK,
+    disabledStart: CCLPastelColor.LEMON_YELLOW,
+    disabledEnd: CCLPastelColor.PEACH_PINK
+  };
+
+  const gradientStops: Record<string, GradientStops> = {
+    [CCLVividColor.STRAWBERRY_PINK]: fallbackStops,
+    [CCLVividColor.PINEAPPLE_YELLOW]: {
+      primaryStart: CCLVividColor.PINEAPPLE_YELLOW,
+      primaryEnd: CCLVividColor.MELON_GREEN,
+      secondaryStart: CCLPastelColor.LEMON_YELLOW,
+      secondaryEnd: CCLVividColor.PINEAPPLE_YELLOW,
+      disabledStart: CCLPastelColor.LEMON_YELLOW,
+      disabledEnd: CCLPastelColor.PEACH_PINK
+    },
+    [CCLVividColor.SODA_BLUE]: {
+      primaryStart: CCLVividColor.SODA_BLUE,
+      primaryEnd: CCLVividColor.GRAPE_PURPLE,
+      secondaryStart: CCLPastelColor.SUGAR_BLUE,
+      secondaryEnd: CCLVividColor.SODA_BLUE,
+      disabledStart: CCLPastelColor.SUGAR_BLUE,
+      disabledEnd: CCLPastelColor.CLOUD_GREY
+    },
+    [CCLVividColor.MELON_GREEN]: {
+      primaryStart: CCLVividColor.MELON_GREEN,
+      primaryEnd: CCLVividColor.SODA_BLUE,
+      secondaryStart: CCLPastelColor.MATCHA_GREEN,
+      secondaryEnd: CCLVividColor.MELON_GREEN,
+      disabledStart: CCLPastelColor.MATCHA_GREEN,
+      disabledEnd: CCLPastelColor.CLOUD_GREY
+    },
+    [CCLVividColor.GRAPE_PURPLE]: {
+      primaryStart: CCLVividColor.GRAPE_PURPLE,
+      primaryEnd: CCLVividColor.PINEAPPLE_YELLOW,
+      secondaryStart: CCLPastelColor.AKEBI_PURPLE,
+      secondaryEnd: CCLVividColor.GRAPE_PURPLE,
+      disabledStart: CCLPastelColor.AKEBI_PURPLE,
+      disabledEnd: CCLPastelColor.CLOUD_GREY
+    },
+    [CCLVividColor.WRAP_GREY]: {
+      primaryStart: CCLVividColor.WRAP_GREY,
+      primaryEnd: CCLVividColor.PINEAPPLE_YELLOW,
+      secondaryStart: CCLPastelColor.CLOUD_GREY,
+      secondaryEnd: CCLVividColor.WRAP_GREY,
+      disabledStart: CCLPastelColor.CLOUD_GREY,
+      disabledEnd: CCLPastelColor.CLOUD_GREY
+    }
+  };
+
+  $: stops = gradientStops[color] ?? fallbackStops;
+  $: gradientStart = disabled
+    ? stops.disabledStart
+    : tone === 'secondary'
+      ? stops.secondaryStart
+      : stops.primaryStart;
+  $: gradientEnd = disabled
+    ? stops.disabledEnd
+    : tone === 'secondary'
+      ? stops.secondaryEnd
+      : stops.primaryEnd;
+  $: gradientStartValue = `var(${gradientStart})`;
+  $: gradientEndValue =
+    color === CCLVividColor.WRAP_GREY && !disabled
+      ? `color-mix(in srgb, var(${CCLVividColor.WRAP_GREY}) 14%, Canvas)`
+      : `var(${gradientEnd})`;
+  $: labelColor = disabled
+    ? `var(${CCLVividColor.WRAP_GREY})`
+    : 'var(--prismatic-gradient-button-primary-fg, Canvas)';
+</script>
+
+<button
+  class="prismatic-gradient-button tone-{tone} size-{size}"
+  style="--gradient-start: {gradientStartValue}; --gradient-end: {gradientEndValue}; --label-color: {labelColor};"
+  on:click={onClick}
+  {disabled}
+  {type}
+>
+  <span class="label">{label}</span>
+</button>
+
+<style>
+  .prismatic-gradient-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: fit-content;
+    min-width: 156px;
+    border: 0;
+    border-radius: 999px;
+    background: linear-gradient(105deg, var(--gradient-start), var(--gradient-end));
+    color: var(--label-color);
+    font-family: inherit;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+      transform 160ms ease,
+      filter 160ms ease,
+      opacity 160ms ease;
+  }
+
+  .size-large {
+    min-height: 48px;
+    padding: 0 28px;
+    font-size: 14px;
+  }
+
+  .size-medium {
+    min-height: 40px;
+    min-width: 132px;
+    padding: 0 22px;
+    font-size: 12px;
+  }
+
+  .tone-secondary {
+    color: var(--label-color);
+  }
+
+  .prismatic-gradient-button:hover:not(:disabled) {
+    filter: saturate(1.08) brightness(1.02);
+    transform: translateY(-1px);
+  }
+
+  .prismatic-gradient-button:active:not(:disabled) {
+    filter: saturate(1.02) brightness(0.96);
+    transform: translateY(0);
+  }
+
+  .prismatic-gradient-button:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--gradient-end) 48%, Canvas);
+    outline-offset: 3px;
+  }
+
+  .prismatic-gradient-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.68;
+  }
+
+  .label {
+    display: inline-flex;
+    align-items: center;
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,6 +2,7 @@
 import './const/variables.css'; // カスタムプロパティ読み込み用
 export { default as Header } from './Header.svelte';
 export { default as Button } from './Button.svelte';
+export { default as PrismaticGradientButton } from './PrismaticGradientButton.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticGradientButtonWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticGradientButtonWrapper.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import PrismaticGradientButton from '../../lib/PrismaticGradientButton.svelte';
+  import { CCLVividColor } from '../../lib/const/config';
+
+  const vividColors = Object.entries(CCLVividColor);
+</script>
+
+<div class="color-palette">
+  <section>
+    <h2>Primary</h2>
+    <div class="color-grid">
+      {#each vividColors as [name, color]}
+        <div class="color-sample">
+          <PrismaticGradientButton {color} label={name} tone="primary" size="large" />
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section>
+    <h2>Secondary</h2>
+    <div class="color-grid">
+      {#each vividColors as [name, color]}
+        <div class="color-sample">
+          <PrismaticGradientButton {color} label={name} tone="secondary" size="medium" />
+        </div>
+      {/each}
+    </div>
+  </section>
+</div>
+
+<style>
+  .color-palette {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 1rem;
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  .color-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .color-sample {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 72px;
+  }
+</style>

--- a/src/stories/PrismaticGradientButton.stories.ts
+++ b/src/stories/PrismaticGradientButton.stories.ts
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import PrismaticGradientButton from '$lib/PrismaticGradientButton.svelte';
+import { CCLVividColor } from '$lib/const/config';
+import { expect, fn, userEvent, within } from '@storybook/test';
+import AllColorsPrismaticGradientButtonWrapper from './AllColors/AllColorsPrismaticGradientButtonWrapper.svelte';
+
+const colorOptions = [
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.PINEAPPLE_YELLOW,
+  CCLVividColor.SODA_BLUE,
+  CCLVividColor.MELON_GREEN,
+  CCLVividColor.GRAPE_PURPLE,
+  CCLVividColor.WRAP_GREY
+];
+
+const meta = {
+  title: 'CommonComponents/PrismaticGradientButton',
+  component: PrismaticGradientButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    tone: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary']
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['large', 'medium']
+    },
+    color: {
+      control: { type: 'select' },
+      options: colorOptions
+    },
+    disabled: {
+      control: { type: 'boolean' }
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['button', 'submit', 'reset']
+    },
+    onClick: fn()
+  }
+} satisfies Meta<PrismaticGradientButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createStory = (
+  label: string,
+  tone: 'primary' | 'secondary',
+  size: 'large' | 'medium',
+  color: string,
+  disabled: boolean = false
+): Story => ({
+  args: {
+    label,
+    tone,
+    size,
+    color,
+    disabled,
+    type: 'button',
+    onClick: fn()
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: label });
+
+    await step('ボタンが表示されていること', async () => {
+      await expect(button).toBeInTheDocument();
+    });
+
+    await step('ラベルが表示されていること', async () => {
+      await expect(canvas.getByText(label)).toBeInTheDocument();
+    });
+
+    await step('toneとsizeが反映されていること', async () => {
+      await expect(args.tone).toBe(tone);
+      await expect(args.size).toBe(size);
+    });
+
+    if (disabled) {
+      await step('非活性状態であること', async () => {
+        await expect(button).toBeDisabled();
+      });
+
+      await step('クリックしてもonClickが呼ばれないこと', async () => {
+        await userEvent.click(button);
+        await expect(args.onClick).not.toHaveBeenCalled();
+      });
+    } else {
+      await step('活性状態であること', async () => {
+        await expect(button).toBeEnabled();
+      });
+
+      await step('クリックするとonClickが呼ばれること', async () => {
+        await userEvent.click(button);
+        await expect(args.onClick).toHaveBeenCalled();
+      });
+    }
+  }
+});
+
+export const Default = createStory(
+  'EXPLORE THE LAB',
+  'primary',
+  'large',
+  CCLVividColor.STRAWBERRY_PINK
+);
+
+export const Secondary = createStory(
+  'EXPLORE THE LAB',
+  'secondary',
+  'medium',
+  CCLVividColor.PINEAPPLE_YELLOW
+);
+
+export const Disabled = createStory(
+  'EXPLORE THE LAB',
+  'secondary',
+  'large',
+  CCLVividColor.PINEAPPLE_YELLOW,
+  true
+);
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticGradientButtonWrapper }),
+  args: {},
+  tags: ['test-prismatic-gradient-button-all-colors'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Primaryの6色が表示されていること', async () => {
+      const primarySection = canvas.getByRole('heading', { name: 'Primary' }).closest('section');
+
+      await expect(primarySection).not.toBeNull();
+      await expect(within(primarySection as HTMLElement).getAllByRole('button')).toHaveLength(6);
+    });
+
+    await step('Secondaryの6色が表示されていること', async () => {
+      const secondarySection = canvas.getByRole('heading', { name: 'Secondary' }).closest('section');
+
+      await expect(secondarySection).not.toBeNull();
+      await expect(within(secondarySection as HTMLElement).getAllByRole('button')).toHaveLength(6);
+    });
+
+    await step('各色のボタンがPrimaryとSecondaryに1つずつ表示されていること', async () => {
+      await expect(canvas.getAllByText('STRAWBERRY_PINK')).toHaveLength(2);
+      await expect(canvas.getAllByText('PINEAPPLE_YELLOW')).toHaveLength(2);
+      await expect(canvas.getAllByText('SODA_BLUE')).toHaveLength(2);
+      await expect(canvas.getAllByText('MELON_GREEN')).toHaveLength(2);
+      await expect(canvas.getAllByText('GRAPE_PURPLE')).toHaveLength(2);
+      await expect(canvas.getAllByText('WRAP_GREY')).toHaveLength(2);
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- Add PrismaticGradientButton with primary/secondary tones, large/medium sizes, disabled state, and six Prismatic color variations
- Export the component from src/lib/index.ts
- Add Storybook stories and an AllColors interaction test for the full color matrix

## Validation
- pnpm exec test-storybook --url http://127.0.0.1:6006 --includeTags test-prismatic-gradient-button-all-colors --maxWorkers 1
- pnpm build-storybook

## Notes
- pnpm check was attempted earlier, but this repository currently reports existing unrelated Svelte/type errors in generated and pre-existing files.