### PR TITLE
[Prismatic Design] SectionHeadingを実装する

### DIFF
--- a/src/lib/PrismaticSectionHeading.svelte
+++ b/src/lib/PrismaticSectionHeading.svelte
@@ -1,0 +1,72 @@
+<script module lang="ts">
+  export type PrismaticSectionHeadingTone =
+    | '--strawberry-pink'
+    | '--pineapple-yellow'
+    | '--soda-blue'
+    | '--melon-green'
+    | '--grape-purple'
+    | '--wrap-grey';
+
+  export type PrismaticSectionHeadingProps = {
+    eyebrow?: string;
+    title?: string;
+    tone?: PrismaticSectionHeadingTone;
+  };
+</script>
+
+<script lang="ts">
+  import { CCLVividColor } from './const/config';
+
+  let {
+    eyebrow = 'LATEST',
+    title = 'Latest Stories',
+    tone = CCLVividColor.STRAWBERRY_PINK
+  }: PrismaticSectionHeadingProps = $props();
+
+  let toneValue = $derived(`var(${tone})`);
+</script>
+
+<div class="prismatic-section-heading" style="--eyebrow-color: {toneValue};">
+  <p class="eyebrow">{eyebrow}</p>
+  <h2 class="title">{title}</h2>
+</div>
+
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DotGothic16&display=swap');
+
+  .prismatic-section-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    width: min(100%, 600px);
+    min-height: 80px;
+    color: color-mix(in srgb, var(--palette-grape-900) 42%, var(--palette-wrap-900));
+    font-family: 'DotGothic16', sans-serif;
+    font-weight: 400;
+    line-height: normal;
+    letter-spacing: 0;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .eyebrow,
+  .title {
+    margin: 0;
+    max-width: 100%;
+    font-weight: 400;
+  }
+
+  .eyebrow {
+    color: var(--eyebrow-color);
+    font-size: 12px;
+    line-height: 1.25;
+    text-transform: uppercase;
+  }
+
+  .title {
+    color: inherit;
+    font-size: 42px;
+    line-height: 1.05;
+  }
+</style>

--- a/src/lib/PrismaticSectionHeading.svelte
+++ b/src/lib/PrismaticSectionHeading.svelte
@@ -1,4 +1,4 @@
-<script module lang="ts">
+<script context="module" lang="ts">
   export type PrismaticSectionHeadingTone =
     | '--strawberry-pink'
     | '--pineapple-yellow'
@@ -17,13 +17,11 @@
 <script lang="ts">
   import { CCLVividColor } from './const/config';
 
-  let {
-    eyebrow = 'LATEST',
-    title = 'Latest Stories',
-    tone = CCLVividColor.STRAWBERRY_PINK
-  }: PrismaticSectionHeadingProps = $props();
+  export let eyebrow: string = 'LATEST';
+  export let title: string = 'Latest Stories';
+  export let tone: PrismaticSectionHeadingTone = CCLVividColor.STRAWBERRY_PINK;
 
-  let toneValue = $derived(`var(${tone})`);
+  $: toneValue = `var(${tone})`;
 </script>
 
 <div class="prismatic-section-heading" style="--eyebrow-color: {toneValue};">

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,6 +3,7 @@ import './const/variables.css'; // カスタムプロパティ読み込み用
 export { default as Header } from './Header.svelte';
 export { default as Button } from './Button.svelte';
 export { default as PrismaticGradientButton } from './PrismaticGradientButton.svelte';
+export { default as PrismaticSectionHeading } from './PrismaticSectionHeading.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticSectionHeadingWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticSectionHeadingWrapper.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import PrismaticSectionHeading from '../../lib/PrismaticSectionHeading.svelte';
+  import { CCLVividColor } from '../../lib/const/config';
+
+  const vividColors = Object.entries(CCLVividColor);
+</script>
+
+<div class="color-palette">
+  <section>
+    <h2>Vivid Colors</h2>
+    <div class="color-grid">
+      {#each vividColors as [name, tone] (name)}
+        <div class="color-sample">
+          <PrismaticSectionHeading eyebrow={name} title="Latest Stories" {tone} />
+        </div>
+      {/each}
+    </div>
+  </section>
+</div>
+
+<style>
+  .color-palette {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 1rem;
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  .color-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .color-sample {
+    display: flex;
+    align-items: flex-start;
+    min-height: 112px;
+  }
+</style>

--- a/src/stories/PrismaticSectionHeading.stories.ts
+++ b/src/stories/PrismaticSectionHeading.stories.ts
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import PrismaticSectionHeading from '$lib/PrismaticSectionHeading.svelte';
+import { CCLVividColor } from '$lib/const/config';
+import { expect, within } from '@storybook/test';
+import AllColorsPrismaticSectionHeadingWrapper from './AllColors/AllColorsPrismaticSectionHeadingWrapper.svelte';
+
+const toneOptions = [
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.PINEAPPLE_YELLOW,
+  CCLVividColor.SODA_BLUE,
+  CCLVividColor.MELON_GREEN,
+  CCLVividColor.GRAPE_PURPLE,
+  CCLVividColor.WRAP_GREY
+];
+
+const meta = {
+  title: 'CommonComponents/PrismaticSectionHeading',
+  component: PrismaticSectionHeading,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    eyebrow: {
+      control: { type: 'text' }
+    },
+    title: {
+      control: { type: 'text' }
+    },
+    tone: {
+      control: { type: 'select' },
+      options: toneOptions
+    }
+  }
+} satisfies Meta<PrismaticSectionHeading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createStory = (eyebrow: string, title: string, tone: string): Story => ({
+  args: {
+    eyebrow,
+    title,
+    tone
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('eyebrowが表示されていること', async () => {
+      await expect(canvas.getByText(eyebrow)).toBeInTheDocument();
+    });
+
+    await step('titleが見出しとして表示されていること', async () => {
+      await expect(canvas.getByRole('heading', { name: title, level: 2 })).toBeInTheDocument();
+    });
+
+    await step('toneが反映されていること', async () => {
+      await expect(args.tone).toBe(tone);
+    });
+  }
+});
+
+export const Default = createStory('LATEST', 'Latest Stories', CCLVividColor.STRAWBERRY_PINK);
+
+export const SodaTone = createStory('COLLECTION', 'Prismatic Works', CCLVividColor.SODA_BLUE);
+
+export const Japanese = createStory(
+  '最新のお知らせ',
+  'キャンディ工房の物語',
+  CCLVividColor.MELON_GREEN
+);
+
+export const LongTitle = createStory(
+  'FEATURED',
+  'A Very Long Section Heading That Wraps Without Breaking The Layout',
+  CCLVividColor.GRAPE_PURPLE
+);
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticSectionHeadingWrapper }),
+  args: {},
+  tags: ['test-prismatic-section-heading-all-colors'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Vivid Colorsの6色が表示されていること', async () => {
+      const section = canvas.getByRole('heading', { name: 'Vivid Colors' }).closest('section');
+
+      await expect(section).not.toBeNull();
+      await expect(
+        within(section as HTMLElement).getAllByRole('heading', { level: 2 })
+      ).toHaveLength(7);
+    });
+
+    await step('各tone名が表示されていること', async () => {
+      await expect(canvas.getByText('STRAWBERRY_PINK')).toBeInTheDocument();
+      await expect(canvas.getByText('PINEAPPLE_YELLOW')).toBeInTheDocument();
+      await expect(canvas.getByText('SODA_BLUE')).toBeInTheDocument();
+      await expect(canvas.getByText('MELON_GREEN')).toBeInTheDocument();
+      await expect(canvas.getByText('GRAPE_PURPLE')).toBeInTheDocument();
+      await expect(canvas.getByText('WRAP_GREY')).toBeInTheDocument();
+    });
+  }
+};


### PR DESCRIPTION
## 概要

Prismatic V2 の Content カタログに合わせて、eyebrow付きの `PrismaticSectionHeading` を追加しました。`tone` によるeyebrow色の切り替え、日本語表示例、DotGothic16による日本語向け見出し表示をStorybookで確認できるようにしています。

## 変更内容

- `src/lib/PrismaticSectionHeading.svelte` を追加し、`eyebrow` / `title` / `tone` propsを実装
- `src/lib/index.ts` から `PrismaticSectionHeading` をexport
- `src/stories/PrismaticSectionHeading.stories.ts` にDefault、SodaTone、日本語表示、長文、All ColorsのStoryとinteraction testを追加
- `src/stories/AllColors/AllColorsPrismaticSectionHeadingWrapper.svelte` を追加し、toneのカラーバリエーションを一覧化
- Google Web Fontsの `DotGothic16` を読み込み、日本語表示の見え方を確認できるように調整

## 確認結果

- Svelte autofixer: 成功
- `pnpm build-storybook`: 成功
- `pnpm check`: 既存の `dist/` / `public/storybook/` 生成物や既存コンポーネント由来のエラーで300秒タイムアウト

## 関連Issue

Closes #84
