### PR TITLE
[Prismatic Design] StoryCardを実装する

### DIFF
--- a/src/lib/PrismaticStoryCard.svelte
+++ b/src/lib/PrismaticStoryCard.svelte
@@ -76,7 +76,7 @@
 
   function handleLinkClick() {
     if (href) {
-      window.open(href, '_blank', 'noopener noreferrer');
+      window.open(href, '_blank', 'noopener,noreferrer');
     }
   }
 </script>
@@ -174,11 +174,20 @@
     object-fit: contain;
   }
 
-  .size-featured .square-image .image {
+  .square-image :global(*) {
+    width: auto;
+    max-width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: contain;
+  }
+
+  .size-featured .square-image .image,
+  .size-featured .square-image :global(*) {
     height: 300px;
   }
 
-  .size-default .square-image .image {
+  .size-default .square-image .image,
+  .size-default .square-image :global(*) {
     height: 230px;
   }
 

--- a/src/lib/PrismaticStoryCard.svelte
+++ b/src/lib/PrismaticStoryCard.svelte
@@ -156,25 +156,25 @@
   }
 
   .image,
-  .image-fallback,
-  .image-slot :global(*) {
+  .image-fallback {
     display: block;
     width: 100%;
     height: 100%;
   }
 
-  .image {
+  .image,
+  .image-slot :global(img),
+  .image-slot :global(video) {
+    display: block;
+    width: 100%;
+    height: 100%;
     object-fit: cover;
   }
 
-  .square-image .image {
-    width: auto;
-    max-width: 100%;
-    aspect-ratio: 1 / 1;
-    object-fit: contain;
-  }
-
-  .square-image :global(*) {
+  .square-image .image,
+  .square-image :global(img),
+  .square-image :global(video) {
+    display: block;
     width: auto;
     max-width: 100%;
     aspect-ratio: 1 / 1;
@@ -182,12 +182,14 @@
   }
 
   .size-featured .square-image .image,
-  .size-featured .square-image :global(*) {
+  .size-featured .square-image :global(img),
+  .size-featured .square-image :global(video) {
     height: 300px;
   }
 
   .size-default .square-image .image,
-  .size-default .square-image :global(*) {
+  .size-default .square-image :global(img),
+  .size-default .square-image :global(video) {
     height: 230px;
   }
 

--- a/src/lib/PrismaticStoryCard.svelte
+++ b/src/lib/PrismaticStoryCard.svelte
@@ -68,17 +68,12 @@
       end: CCLPastelColor.SUGAR_BLUE
     }
   };
+  const linkElement = 'a';
 
   $: stops = gradientStops[tone] ?? fallbackStops;
   $: gradientStart = `var(${stops.start})`;
   $: gradientEnd = `var(${stops.end})`;
   $: accentColor = `var(${tone})`;
-
-  function handleLinkClick() {
-    if (href) {
-      window.open(href, '_blank', 'noopener,noreferrer');
-    }
-  }
 </script>
 
 <article
@@ -107,7 +102,15 @@
     <h3 class="title">{title}</h3>
 
     {#if href}
-      <button class="link" type="button" on:click={handleLinkClick}>{linkLabel}</button>
+      <svelte:element
+        this={linkElement}
+        class="link"
+        {href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {linkLabel}
+      </svelte:element>
     {/if}
   </div>
 </article>
@@ -243,12 +246,7 @@
 
   .link {
     margin-top: auto;
-    padding: 0;
-    border: 0;
-    background: transparent;
     color: var(--accent-color);
-    cursor: pointer;
-    font-family: inherit;
     font-size: 13px;
     font-weight: 700;
     line-height: 1.4;

--- a/src/lib/PrismaticStoryCard.svelte
+++ b/src/lib/PrismaticStoryCard.svelte
@@ -1,0 +1,255 @@
+<script context="module" lang="ts">
+  export type PrismaticStoryCardSize = 'featured' | 'default';
+  export type PrismaticStoryCardTone =
+    | '--strawberry-pink'
+    | '--pineapple-yellow'
+    | '--soda-blue'
+    | '--melon-green'
+    | '--grape-purple'
+    | '--wrap-grey';
+
+  export type PrismaticStoryCardProps = {
+    title?: string;
+    label?: string;
+    href?: string;
+    linkLabel?: string;
+    imageUrl?: string;
+    imageAlt?: string;
+    squareImage?: boolean;
+    size?: PrismaticStoryCardSize;
+    tone?: PrismaticStoryCardTone;
+  };
+</script>
+
+<script lang="ts">
+  import { CCLPastelColor, CCLVividColor } from './const/config';
+  import type { ColorVar } from './const/config';
+
+  type GradientStops = {
+    start: ColorVar;
+    end: ColorVar;
+  };
+
+  export let title: string = '技術書典20・新刊のお知らせ';
+  export let label: string | undefined = undefined;
+  export let href: string | undefined = undefined;
+  export let linkLabel: string = 'Read more';
+  export let imageUrl: string | undefined = undefined;
+  export let imageAlt: string = '';
+  export let squareImage: boolean = false;
+  export let size: PrismaticStoryCardSize = 'featured';
+  export let tone: PrismaticStoryCardTone = CCLVividColor.STRAWBERRY_PINK;
+
+  const fallbackStops: GradientStops = {
+    start: CCLPastelColor.PEACH_PINK,
+    end: CCLPastelColor.SUGAR_BLUE
+  };
+
+  const gradientStops: Record<string, GradientStops> = {
+    [CCLVividColor.STRAWBERRY_PINK]: fallbackStops,
+    [CCLVividColor.PINEAPPLE_YELLOW]: {
+      start: CCLPastelColor.LEMON_YELLOW,
+      end: CCLPastelColor.PEACH_PINK
+    },
+    [CCLVividColor.SODA_BLUE]: {
+      start: CCLPastelColor.SUGAR_BLUE,
+      end: CCLPastelColor.AKEBI_PURPLE
+    },
+    [CCLVividColor.MELON_GREEN]: {
+      start: CCLPastelColor.MATCHA_GREEN,
+      end: CCLPastelColor.SUGAR_BLUE
+    },
+    [CCLVividColor.GRAPE_PURPLE]: {
+      start: CCLPastelColor.AKEBI_PURPLE,
+      end: CCLPastelColor.LEMON_YELLOW
+    },
+    [CCLVividColor.WRAP_GREY]: {
+      start: CCLPastelColor.CLOUD_GREY,
+      end: CCLPastelColor.SUGAR_BLUE
+    }
+  };
+
+  $: stops = gradientStops[tone] ?? fallbackStops;
+  $: gradientStart = `var(${stops.start})`;
+  $: gradientEnd = `var(${stops.end})`;
+  $: accentColor = `var(${tone})`;
+
+  function handleLinkClick() {
+    if (href) {
+      window.open(href, '_blank', 'noopener noreferrer');
+    }
+  }
+</script>
+
+<article
+  class="prismatic-story-card size-{size}"
+  style="--gradient-start: {gradientStart}; --gradient-end: {gradientEnd}; --accent-color: {accentColor};"
+>
+  <div
+    class="image-slot"
+    class:square-image={squareImage}
+    aria-label={imageUrl ? undefined : imageAlt || undefined}
+  >
+    {#if imageUrl}
+      <img class="image" src={imageUrl} alt={imageAlt} />
+    {:else}
+      <slot name="image">
+        <span class="image-fallback" aria-hidden="true"></span>
+      </slot>
+    {/if}
+  </div>
+
+  <div class="body">
+    {#if label}
+      <p class="label">{label}</p>
+    {/if}
+
+    <h3 class="title">{title}</h3>
+
+    {#if href}
+      <button class="link" type="button" on:click={handleLinkClick}>{linkLabel}</button>
+    {/if}
+  </div>
+</article>
+
+<style>
+  .prismatic-story-card {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1.5px solid color-mix(in srgb, var(--gradient-start) 52%, transparent);
+    border-radius: 34px;
+    background: color-mix(in srgb, var(--color-surface-glass) 82%, transparent);
+    box-shadow: 0 18px 38px color-mix(in srgb, var(--palette-grape-900) 16%, transparent);
+    color: color-mix(in srgb, var(--palette-grape-900) 42%, var(--palette-wrap-900));
+    font-family: Inter, sans-serif;
+    letter-spacing: 0;
+  }
+
+  .size-featured {
+    width: min(100%, 600px);
+    min-height: 430px;
+  }
+
+  .size-default {
+    width: 300px;
+    min-height: 360px;
+  }
+
+  .image-slot {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 100%;
+    overflow: hidden;
+    background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+  }
+
+  .size-featured .image-slot {
+    height: 300px;
+  }
+
+  .size-default .image-slot {
+    height: 230px;
+  }
+
+  .image,
+  .image-fallback,
+  .image-slot :global(*) {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .image {
+    object-fit: cover;
+  }
+
+  .square-image .image {
+    width: auto;
+    max-width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: contain;
+  }
+
+  .size-featured .square-image .image {
+    height: 300px;
+  }
+
+  .size-default .square-image .image {
+    height: 230px;
+  }
+
+  .body {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .size-featured .body {
+    padding: 21px 20px 20px;
+  }
+
+  .size-default .body {
+    padding: 20px;
+  }
+
+  .label,
+  .title {
+    margin: 0;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .label {
+    color: var(--accent-color);
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.25;
+    text-transform: uppercase;
+  }
+
+  .title {
+    color: inherit;
+    font-weight: 400;
+    line-height: normal;
+  }
+
+  .size-featured .title {
+    font-size: 24px;
+  }
+
+  .size-default .title {
+    font-size: 18px;
+  }
+
+  .link {
+    margin-top: auto;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--accent-color);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.4;
+    text-decoration: none;
+  }
+
+  .link:hover {
+    text-decoration: underline;
+  }
+
+  .link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent-color) 42%, Canvas);
+    outline-offset: 4px;
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,7 @@ export { default as Header } from './Header.svelte';
 export { default as Button } from './Button.svelte';
 export { default as PrismaticGradientButton } from './PrismaticGradientButton.svelte';
 export { default as PrismaticSectionHeading } from './PrismaticSectionHeading.svelte';
+export { default as PrismaticStoryCard } from './PrismaticStoryCard.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticStoryCardWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticStoryCardWrapper.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+  import PrismaticStoryCard from '../../lib/PrismaticStoryCard.svelte';
+  import { CCLVividColor } from '../../lib/const/config';
+
+  const vividColors = Object.entries(CCLVividColor);
+</script>
+
+<div class="color-palette">
+  <section>
+    <h2>Featured</h2>
+    <div class="featured-grid">
+      {#each vividColors as [name, tone] (name)}
+        <div class="color-sample">
+          <PrismaticStoryCard title={`${name} のストーリー`} label={name} {tone} size="featured" />
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section>
+    <h2>Default</h2>
+    <div class="default-grid">
+      {#each vividColors as [name, tone] (name)}
+        <div class="color-sample">
+          <PrismaticStoryCard title={`${name} のストーリー`} label={name} {tone} size="default" />
+        </div>
+      {/each}
+    </div>
+  </section>
+</div>
+
+<style>
+  .color-palette {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 1rem;
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  .featured-grid,
+  .default-grid {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .featured-grid {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 600px));
+  }
+
+  .default-grid {
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  }
+
+  .color-sample {
+    display: flex;
+    align-items: flex-start;
+  }
+</style>

--- a/src/stories/PrismaticStoryCard.stories.ts
+++ b/src/stories/PrismaticStoryCard.stories.ts
@@ -91,8 +91,11 @@ const createStory = (
     }
 
     if (href) {
-      await step('CTAボタンが表示されていること', async () => {
-        await expect(canvas.getByRole('button', { name: args.linkLabel })).toBeInTheDocument();
+      await step('CTAリンクが表示されていること', async () => {
+        await expect(canvas.getByRole('link', { name: args.linkLabel })).toHaveAttribute(
+          'href',
+          href
+        );
       });
     }
   }

--- a/src/stories/PrismaticStoryCard.stories.ts
+++ b/src/stories/PrismaticStoryCard.stories.ts
@@ -1,0 +1,214 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import PrismaticStoryCard from '$lib/PrismaticStoryCard.svelte';
+import { CCLVividColor } from '$lib/const/config';
+import { expect, within } from '@storybook/test';
+import AllColorsPrismaticStoryCardWrapper from './AllColors/AllColorsPrismaticStoryCardWrapper.svelte';
+
+const toneOptions = [
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.PINEAPPLE_YELLOW,
+  CCLVividColor.SODA_BLUE,
+  CCLVividColor.MELON_GREEN,
+  CCLVividColor.GRAPE_PURPLE,
+  CCLVividColor.WRAP_GREY
+];
+
+const meta = {
+  title: 'CommonComponents/PrismaticStoryCard',
+  component: PrismaticStoryCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    title: {
+      control: { type: 'text' }
+    },
+    label: {
+      control: { type: 'text' }
+    },
+    href: {
+      control: { type: 'text' }
+    },
+    linkLabel: {
+      control: { type: 'text' }
+    },
+    imageUrl: {
+      control: { type: 'text' }
+    },
+    imageAlt: {
+      control: { type: 'text' }
+    },
+    squareImage: {
+      control: { type: 'boolean' }
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['featured', 'default']
+    },
+    tone: {
+      control: { type: 'select' },
+      options: toneOptions
+    }
+  }
+} satisfies Meta<PrismaticStoryCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const createStory = (
+  title: string,
+  size: 'featured' | 'default',
+  tone: string,
+  label?: string,
+  href?: string
+): Story => ({
+  args: {
+    title,
+    label,
+    href,
+    linkLabel: '記事を読む',
+    size,
+    tone
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('タイトルが見出しとして表示されていること', async () => {
+      await expect(canvas.getByRole('heading', { name: title, level: 3 })).toBeInTheDocument();
+    });
+
+    await step('sizeとtoneが反映されていること', async () => {
+      await expect(args.size).toBe(size);
+      await expect(args.tone).toBe(tone);
+    });
+
+    if (label) {
+      await step('ラベルが表示されていること', async () => {
+        await expect(canvas.getByText(label)).toBeInTheDocument();
+      });
+    }
+
+    if (href) {
+      await step('CTAボタンが表示されていること', async () => {
+        await expect(canvas.getByRole('button', { name: args.linkLabel })).toBeInTheDocument();
+      });
+    }
+  }
+});
+
+export const Featured = createStory(
+  '技術書典20・新刊のお知らせ',
+  'featured',
+  CCLVividColor.STRAWBERRY_PINK
+);
+
+export const Default = createStory(
+  '技術書典20・新刊のお知らせ',
+  'default',
+  CCLVividColor.STRAWBERRY_PINK
+);
+
+export const Japanese = createStory(
+  'キャンディ工房の開発日誌を公開しました',
+  'featured',
+  CCLVividColor.MELON_GREEN,
+  'お知らせ',
+  'https://example.com'
+);
+
+export const WithImage: Story = {
+  args: {
+    title: '画像を差し込んだStoryCard',
+    label: 'IMAGE',
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'StoryCardのサムネイル',
+    size: 'default',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('画像にalt属性が設定されていること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'StoryCardのサムネイル');
+    });
+
+    await step('タイトルが表示されていること', async () => {
+      await expect(canvas.getByText('画像を差し込んだStoryCard')).toBeInTheDocument();
+    });
+  }
+};
+
+export const WithSquareImage: Story = {
+  args: {
+    title: '正方形画像を中央に配置したStoryCard',
+    label: 'SQUARE IMAGE',
+    imageUrl: 'thumbnail.png',
+    imageAlt: '正方形画像のStoryCardサムネイル',
+    squareImage: true,
+    size: 'featured',
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('正方形画像フラグが有効であること', async () => {
+      await expect(args.squareImage).toBe(true);
+    });
+
+    await step('画像にalt属性が設定されていること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute(
+        'alt',
+        '正方形画像のStoryCardサムネイル'
+      );
+    });
+
+    await step('タイトルが表示されていること', async () => {
+      await expect(canvas.getByText('正方形画像を中央に配置したStoryCard')).toBeInTheDocument();
+    });
+  }
+};
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticStoryCardWrapper }),
+  args: {},
+  tags: ['test-prismatic-story-card-all-colors'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Featuredの6色が表示されていること', async () => {
+      const section = canvas.getByRole('heading', { name: 'Featured' }).closest('section');
+
+      await expect(section).not.toBeNull();
+      await expect(
+        within(section as HTMLElement).getAllByRole('heading', { level: 3 })
+      ).toHaveLength(6);
+    });
+
+    await step('Defaultの6色が表示されていること', async () => {
+      const section = canvas.getByRole('heading', { name: 'Default' }).closest('section');
+
+      await expect(section).not.toBeNull();
+      await expect(
+        within(section as HTMLElement).getAllByRole('heading', { level: 3 })
+      ).toHaveLength(6);
+    });
+
+    await step('各tone名がFeaturedとDefaultに1つずつ表示されていること', async () => {
+      await expect(canvas.getAllByText('STRAWBERRY_PINK')).toHaveLength(2);
+      await expect(canvas.getAllByText('PINEAPPLE_YELLOW')).toHaveLength(2);
+      await expect(canvas.getAllByText('SODA_BLUE')).toHaveLength(2);
+      await expect(canvas.getAllByText('MELON_GREEN')).toHaveLength(2);
+      await expect(canvas.getAllByText('GRAPE_PURPLE')).toHaveLength(2);
+      await expect(canvas.getAllByText('WRAP_GREY')).toHaveLength(2);
+    });
+  }
+};

--- a/src/stories/PrismaticStoryCard.stories.ts
+++ b/src/stories/PrismaticStoryCard.stories.ts
@@ -3,6 +3,7 @@ import PrismaticStoryCard from '$lib/PrismaticStoryCard.svelte';
 import { CCLVividColor } from '$lib/const/config';
 import { expect, within } from '@storybook/test';
 import AllColorsPrismaticStoryCardWrapper from './AllColors/AllColorsPrismaticStoryCardWrapper.svelte';
+import PrismaticStoryCardSquareSlotWrapper from './PrismaticStoryCardSquareSlotWrapper.svelte';
 
 const toneOptions = [
   CCLVividColor.STRAWBERRY_PINK,
@@ -165,6 +166,32 @@ export const WithSquareImage: Story = {
 
     await step('タイトルが表示されていること', async () => {
       await expect(canvas.getByText('正方形画像を中央に配置したStoryCard')).toBeInTheDocument();
+    });
+  }
+};
+
+export const WithSquareSlotImage: Story = {
+  render: () => ({ Component: PrismaticStoryCardSquareSlotWrapper }),
+  args: {},
+  parameters: {
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('slot経由の画像にalt属性が設定されていること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute(
+        'alt',
+        'slot経由の正方形画像サムネイル'
+      );
+    });
+
+    await step('タイトルが表示されていること', async () => {
+      await expect(canvas.getByText('slotで正方形画像を差し込んだStoryCard')).toBeInTheDocument();
     });
   }
 };

--- a/src/stories/PrismaticStoryCardSquareSlotWrapper.svelte
+++ b/src/stories/PrismaticStoryCardSquareSlotWrapper.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import PrismaticStoryCard from '$lib/PrismaticStoryCard.svelte';
+  import { CCLVividColor } from '$lib/const/config';
+</script>
+
+<PrismaticStoryCard
+  title="slotで正方形画像を差し込んだStoryCard"
+  label="SQUARE SLOT"
+  squareImage
+  size="featured"
+  tone={CCLVividColor.GRAPE_PURPLE}
+>
+  <img slot="image" src="thumbnail.png" alt="slot経由の正方形画像サムネイル" />
+</PrismaticStoryCard>


### PR DESCRIPTION
## 概要
- Prismatic Design の StoryCard コンポーネントを追加しました。
- Featured / Default のサイズ差、tone別のグラデーション、画像URLまたは image slot に対応しました。
- 正方形画像を中央に収めるための squareImage フラグを追加しました。
- Storybook に標準表示、日本語表示、画像あり、正方形画像、AllColors のStoryを追加しました。

## 関連Issue
Closes #85

## 確認
- Svelte autofixer: 問題なし
- pnpm build-storybook: 成功
- pnpm check: 300秒でタイムアウト。既存の dist / public/storybook / timestamp config 由来のエラーが大量に出ており、今回追加分に起因するエラーは確認されていません。