### PR TITLE
[Prismatic Design] WorkCardを実装

### DIFF
--- a/src/lib/PrismaticWorkCard.svelte
+++ b/src/lib/PrismaticWorkCard.svelte
@@ -1,0 +1,228 @@
+<script context="module" lang="ts">
+  export type PrismaticWorkCardTone =
+    | '--strawberry-pink'
+    | '--pineapple-yellow'
+    | '--soda-blue'
+    | '--melon-green'
+    | '--grape-purple'
+    | '--wrap-grey';
+
+  export type PrismaticWorkCardProps = {
+    title?: string;
+    href?: string;
+    linkLabel?: string;
+    imageUrl?: string;
+    imageAlt?: string;
+    tone?: PrismaticWorkCardTone;
+  };
+</script>
+
+<script lang="ts">
+  import { CCLPastelColor, CCLVividColor } from './const/config';
+  import type { ColorVar } from './const/config';
+
+  export let title: string = 'CCL Component Kit';
+  export let href: string | undefined = undefined;
+  export let linkLabel: string = 'VIEW PROJECT';
+  export let imageUrl: string | undefined = undefined;
+  export let imageAlt: string = '';
+  export let tone: PrismaticWorkCardTone = CCLVividColor.STRAWBERRY_PINK;
+
+  const imageColors: Record<string, ColorVar> = {
+    [CCLVividColor.STRAWBERRY_PINK]: CCLPastelColor.PEACH_PINK,
+    [CCLVividColor.PINEAPPLE_YELLOW]: CCLPastelColor.LEMON_YELLOW,
+    [CCLVividColor.SODA_BLUE]: CCLPastelColor.SUGAR_BLUE,
+    [CCLVividColor.MELON_GREEN]: CCLPastelColor.MATCHA_GREEN,
+    [CCLVividColor.GRAPE_PURPLE]: CCLPastelColor.AKEBI_PURPLE,
+    [CCLVividColor.WRAP_GREY]: CCLPastelColor.CLOUD_GREY
+  };
+  const linkElement = 'a';
+
+  $: accentColor = `var(${tone})`;
+  $: imageColor = `var(${imageColors[tone] ?? CCLPastelColor.PEACH_PINK})`;
+</script>
+
+<article
+  class="prismatic-work-card"
+  style="--accent-color: {accentColor}; --image-color: {imageColor};"
+>
+  <div class="image-slot" aria-label={imageUrl ? undefined : imageAlt || undefined}>
+    {#if imageUrl}
+      <img class="image" src={imageUrl} alt={imageAlt} />
+    {:else}
+      <slot name="image">
+        <span class="image-fallback" aria-hidden="true"></span>
+      </slot>
+    {/if}
+  </div>
+
+  <div class="body">
+    <h3 class="title">{title}</h3>
+
+    {#if href}
+      <svelte:element
+        this={linkElement}
+        class="link"
+        {href}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span>{linkLabel}</span>
+        <svg class="link-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+          <path d="M5 3.5L9.5 8L5 12.5" />
+          <path d="M9 8H2.5" />
+        </svg>
+      </svelte:element>
+    {:else}
+      <span class="link-label">
+        <span>{linkLabel}</span>
+        <svg class="link-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+          <path d="M5 3.5L9.5 8L5 12.5" />
+          <path d="M9 8H2.5" />
+        </svg>
+      </span>
+    {/if}
+  </div>
+</article>
+
+<style>
+  .prismatic-work-card {
+    display: flex;
+    align-items: center;
+    gap: 44px;
+    width: min(100%, 620px);
+    min-height: 250px;
+    box-sizing: border-box;
+    padding: 38px 32px;
+    border: 1.5px solid color-mix(in srgb, var(--accent-color) 52%, transparent);
+    border-radius: 34px;
+    background: color-mix(in srgb, var(--color-surface-glass) 72%, transparent);
+    color: color-mix(in srgb, var(--palette-grape-900) 42%, var(--palette-wrap-900));
+    font-family: Inter, sans-serif;
+    letter-spacing: 0;
+  }
+
+  .image-slot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 170px;
+    width: 170px;
+    height: 170px;
+    overflow: hidden;
+    border-radius: 24px;
+    background: var(--image-color);
+  }
+
+  .image,
+  .image-fallback {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .image,
+  .image-slot :global(img),
+  .image-slot :global(video) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .body {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 58px;
+    min-width: 0;
+  }
+
+  .title {
+    margin: 0;
+    max-width: 100%;
+    color: inherit;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: normal;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .link,
+  .link-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    width: fit-content;
+    color: var(--accent-color);
+    font-size: 15px;
+    font-weight: 700;
+    line-height: normal;
+    text-decoration: none;
+  }
+
+  .link-icon {
+    display: block;
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .link:hover {
+    text-decoration: underline;
+  }
+
+  .link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent-color) 42%, Canvas);
+    outline-offset: 4px;
+  }
+
+  @media (max-width: 640px) {
+    .prismatic-work-card {
+      align-items: flex-start;
+      gap: 24px;
+      min-height: auto;
+      padding: 24px;
+    }
+
+    .image-slot {
+      flex-basis: 132px;
+      width: 132px;
+      height: 132px;
+      border-radius: 20px;
+    }
+
+    .body {
+      gap: 32px;
+      min-height: 132px;
+    }
+
+    .title {
+      font-size: 22px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .prismatic-work-card {
+      flex-direction: column;
+    }
+
+    .image-slot {
+      width: min(100%, 170px);
+      height: auto;
+      aspect-ratio: 1 / 1;
+    }
+
+    .body {
+      min-height: auto;
+    }
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,7 @@ export { default as Button } from './Button.svelte';
 export { default as PrismaticGradientButton } from './PrismaticGradientButton.svelte';
 export { default as PrismaticSectionHeading } from './PrismaticSectionHeading.svelte';
 export { default as PrismaticStoryCard } from './PrismaticStoryCard.svelte';
+export { default as PrismaticWorkCard } from './PrismaticWorkCard.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticWorkCardWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticWorkCardWrapper.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import PrismaticWorkCard from '../../lib/PrismaticWorkCard.svelte';
+  import { CCLVividColor } from '../../lib/const/config';
+
+  const vividColors = Object.entries(CCLVividColor);
+</script>
+
+<div class="color-palette">
+  <section>
+    <h2>WorkCard</h2>
+    <div class="work-card-grid">
+      {#each vividColors as [name, tone] (name)}
+        <div class="color-sample">
+          <PrismaticWorkCard title={`${name} の制作実績`} linkLabel="VIEW PROJECT" {tone} />
+        </div>
+      {/each}
+    </div>
+  </section>
+</div>
+
+<style>
+  .color-palette {
+    padding: 1rem;
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  h2 {
+    margin: 0;
+  }
+
+  .work-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 620px));
+    gap: 1.5rem;
+  }
+
+  .color-sample {
+    display: flex;
+    align-items: flex-start;
+  }
+</style>

--- a/src/stories/PrismaticWorkCard.stories.ts
+++ b/src/stories/PrismaticWorkCard.stories.ts
@@ -1,0 +1,200 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import PrismaticWorkCard from '$lib/PrismaticWorkCard.svelte';
+import { CCLVividColor } from '$lib/const/config';
+import { expect, within } from '@storybook/test';
+import AllColorsPrismaticWorkCardWrapper from './AllColors/AllColorsPrismaticWorkCardWrapper.svelte';
+import PrismaticWorkCardMixedWrapper from './PrismaticWorkCardMixedWrapper.svelte';
+
+const toneOptions = [
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.PINEAPPLE_YELLOW,
+  CCLVividColor.SODA_BLUE,
+  CCLVividColor.MELON_GREEN,
+  CCLVividColor.GRAPE_PURPLE,
+  CCLVividColor.WRAP_GREY
+];
+
+const meta = {
+  title: 'CommonComponents/PrismaticWorkCard',
+  component: PrismaticWorkCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    title: {
+      control: { type: 'text' }
+    },
+    href: {
+      control: { type: 'text' }
+    },
+    linkLabel: {
+      control: { type: 'text' }
+    },
+    imageUrl: {
+      control: { type: 'text' }
+    },
+    imageAlt: {
+      control: { type: 'text' }
+    },
+    tone: {
+      control: { type: 'select' },
+      options: toneOptions
+    }
+  }
+} satisfies Meta<PrismaticWorkCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'CCL Component Kit',
+    href: 'https://example.com',
+    linkLabel: 'VIEW PROJECT',
+    tone: CCLVividColor.STRAWBERRY_PINK
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('タイトルが見出しとして表示されていること', async () => {
+      await expect(
+        canvas.getByRole('heading', { name: 'CCL Component Kit', level: 3 })
+      ).toBeInTheDocument();
+    });
+
+    await step('CTAリンクが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: 'VIEW PROJECT' })).toHaveAttribute(
+        'href',
+        'https://example.com'
+      );
+    });
+  }
+};
+
+export const Japanese: Story = {
+  args: {
+    title: 'キャンディ工房 実績紹介',
+    href: 'https://example.com',
+    linkLabel: '実績を見る',
+    tone: CCLVividColor.MELON_GREEN
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('日本語タイトルが表示されていること', async () => {
+      await expect(
+        canvas.getByRole('heading', { name: 'キャンディ工房 実績紹介', level: 3 })
+      ).toBeInTheDocument();
+    });
+
+    await step('日本語リンクラベルが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: '実績を見る' })).toHaveAttribute(
+        'href',
+        'https://example.com'
+      );
+    });
+  }
+};
+
+export const WithImage: Story = {
+  args: {
+    title: '画像を差し込んだWorkCard',
+    href: 'https://example.com',
+    linkLabel: 'VIEW PROJECT',
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'WorkCardのサムネイル',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('画像にalt属性が設定されていること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'WorkCardのサムネイル');
+    });
+
+    await step('タイトルが表示されていること', async () => {
+      await expect(canvas.getByText('画像を差し込んだWorkCard')).toBeInTheDocument();
+    });
+  }
+};
+
+export const WithoutLink: Story = {
+  args: {
+    title: 'リンクなしの制作実績',
+    linkLabel: 'COMING SOON',
+    tone: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('リンクなしでもラベルが表示されていること', async () => {
+      await expect(canvas.getByText('COMING SOON')).toBeInTheDocument();
+    });
+
+    await step('href未指定ではリンクにならないこと', async () => {
+      await expect(canvas.queryByRole('link', { name: 'COMING SOON' })).not.toBeInTheDocument();
+    });
+  }
+};
+
+export const MixedWithServiceCard: Story = {
+  render: () => ({ Component: PrismaticWorkCardMixedWrapper }),
+  args: {},
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('WorkCardとServiceCardの見出しが表示されていること', async () => {
+      await expect(canvas.getByRole('heading', { name: 'PrismaticWorkCard' })).toBeInTheDocument();
+      await expect(canvas.getByRole('heading', { name: 'ServiceCard' })).toBeInTheDocument();
+    });
+
+    await step('既存ServiceCardとの差分を確認できること', async () => {
+      await expect(canvas.getByText('Prismatic Design の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('既存サービスカード')).toBeInTheDocument();
+    });
+  }
+};
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticWorkCardWrapper }),
+  args: {},
+  tags: ['test-prismatic-work-card-all-colors'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('WorkCardの6色が表示されていること', async () => {
+      const section = canvas.getByRole('heading', { name: 'WorkCard' }).closest('section');
+
+      await expect(section).not.toBeNull();
+      await expect(
+        within(section as HTMLElement).getAllByRole('heading', { level: 3 })
+      ).toHaveLength(6);
+    });
+
+    await step('各tone名の制作実績が表示されていること', async () => {
+      await expect(canvas.getByText('STRAWBERRY_PINK の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('PINEAPPLE_YELLOW の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('SODA_BLUE の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('MELON_GREEN の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('GRAPE_PURPLE の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('WRAP_GREY の制作実績')).toBeInTheDocument();
+    });
+  }
+};

--- a/src/stories/PrismaticWorkCardMixedWrapper.svelte
+++ b/src/stories/PrismaticWorkCardMixedWrapper.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import PrismaticWorkCard from '../lib/PrismaticWorkCard.svelte';
+  import ServiceCard from '../lib/ServiceCard.svelte';
+  import { CCLVividColor } from '../lib/const/config';
+</script>
+
+<div class="comparison">
+  <section class="sample">
+    <h2>PrismaticWorkCard</h2>
+    <PrismaticWorkCard
+      title="Prismatic Design の制作実績"
+      href="https://example.com"
+      linkLabel="VIEW PROJECT"
+      imageUrl="thumbnail.png"
+      imageAlt="PrismaticWorkCardのサムネイル"
+      tone={CCLVividColor.STRAWBERRY_PINK}
+    />
+  </section>
+
+  <section class="sample">
+    <h2>ServiceCard</h2>
+    <ServiceCard
+      serviceName="既存サービスカード"
+      description="サービス説明とリンクをまとめる既存コンポーネントです。"
+      imageUrl="thumbnail.png"
+      altText="ServiceCardのサムネイル"
+      linkUrl="https://example.com"
+      borderColor={CCLVividColor.SODA_BLUE}
+    />
+  </section>
+</div>
+
+<style>
+  .comparison {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 32px;
+    width: min(100%, 1180px);
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  .sample {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-width: 0;
+  }
+
+  h2 {
+    margin: 0;
+    color: color-mix(in srgb, var(--palette-grape-900) 42%, var(--palette-wrap-900));
+    font-family: Inter, sans-serif;
+    font-size: 18px;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+</style>


### PR DESCRIPTION
## 概要

Prismatic Design の WorkCard コンポーネントを追加しました。

- `PrismaticWorkCard` を追加し、左側の画像枠と右側のタイトル / CTA を持つ横長カードを実装
- `tone` に応じて CTA と枠線、画像枠の色が切り替わるように調整
- CTA の矢印はテキストではなくシンプルな SVG アイコンとして表示
- `src/lib/index.ts` から public export を追加
- Storybook に Default / 日本語表示 / 画像あり / リンクなし / ServiceCard 比較 / All Colors を追加

## 確認内容

- Svelte autofixer: 追加した Svelte ファイルで問題なし
- `pnpm build-storybook`: 成功
- `pnpm exec test-storybook --coverage --url http://127.0.0.1:6006 --maxWorkers 1`: `PrismaticWorkCard.stories.ts` は PASS
  - 既存 Story の `Alert` / `RadioButton` / `Pagination` は別件で失敗が残っています

Closes #86