### PR TITLE
[Prismatic Design] BookCardを実装

### DIFF
--- a/src/lib/PrismaticBookCard.svelte
+++ b/src/lib/PrismaticBookCard.svelte
@@ -1,0 +1,175 @@
+<script context="module" lang="ts">
+  export type PrismaticBookCardTone =
+    | '--strawberry-pink'
+    | '--pineapple-yellow'
+    | '--soda-blue'
+    | '--melon-green'
+    | '--grape-purple'
+    | '--wrap-grey';
+
+  export type PrismaticBookCardProps = {
+    href?: string;
+    linkLabel?: string;
+    imageUrl?: string;
+    imageAlt?: string;
+    tone?: PrismaticBookCardTone;
+  };
+</script>
+
+<script lang="ts">
+  import { CCLPastelColor, CCLVividColor } from './const/config';
+  import type { ColorVar } from './const/config';
+
+  export let href: string | undefined = undefined;
+  export let linkLabel: string = 'READ MORE';
+  export let imageUrl: string | undefined = undefined;
+  export let imageAlt: string = '';
+  export let tone: PrismaticBookCardTone = CCLVividColor.STRAWBERRY_PINK;
+
+  const gradientEndColors: Record<string, ColorVar> = {
+    [CCLVividColor.STRAWBERRY_PINK]: CCLPastelColor.LEMON_YELLOW,
+    [CCLVividColor.PINEAPPLE_YELLOW]: CCLPastelColor.PEACH_PINK,
+    [CCLVividColor.SODA_BLUE]: CCLPastelColor.AKEBI_PURPLE,
+    [CCLVividColor.MELON_GREEN]: CCLPastelColor.SUGAR_BLUE,
+    [CCLVividColor.GRAPE_PURPLE]: CCLPastelColor.LEMON_YELLOW,
+    [CCLVividColor.WRAP_GREY]: CCLPastelColor.SUGAR_BLUE
+  };
+  const linkElement = 'a';
+
+  $: gradientStart = `var(${tone})`;
+  $: gradientEnd = `var(${gradientEndColors[tone] ?? CCLPastelColor.LEMON_YELLOW})`;
+  $: accentColor = `var(${tone})`;
+</script>
+
+<article
+  class="prismatic-book-card"
+  style="--gradient-start: {gradientStart}; --gradient-end: {gradientEnd}; --accent-color: {accentColor};"
+>
+  <div class="cover-slot" aria-label={imageUrl ? undefined : imageAlt || undefined}>
+    {#if imageUrl}
+      <img class="cover-image" src={imageUrl} alt={imageAlt} />
+    {:else}
+      <slot name="image">
+        <span class="cover-fallback" aria-hidden="true"></span>
+      </slot>
+    {/if}
+  </div>
+
+  {#if href}
+    <svelte:element
+      this={linkElement}
+      class="link"
+      {href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <span>{linkLabel}</span>
+      <svg class="link-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <path d="M5 3.5L9.5 8L5 12.5" />
+        <path d="M9 8H2.5" />
+      </svg>
+    </svelte:element>
+  {:else}
+    <span class="link-label">
+      <span>{linkLabel}</span>
+      <svg class="link-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <path d="M5 3.5L9.5 8L5 12.5" />
+        <path d="M9 8H2.5" />
+      </svg>
+    </span>
+  {/if}
+</article>
+
+<style>
+  .prismatic-book-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+    width: min(100%, 300px);
+    height: 500px;
+    box-sizing: border-box;
+    padding: 24px;
+    border: 1.5px solid color-mix(in srgb, var(--gradient-end) 60%, transparent);
+    border-radius: 34px;
+    background: color-mix(in srgb, var(--color-surface-glass) 82%, transparent);
+    font-family: Inter, sans-serif;
+    letter-spacing: 0;
+  }
+
+  .cover-slot {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 360px;
+    overflow: hidden;
+    border-radius: 18px;
+    background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+  }
+
+  .cover-image,
+  .cover-fallback {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .cover-image,
+  .cover-slot :global(img),
+  .cover-slot :global(video) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .link,
+  .link-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    width: fit-content;
+    max-width: 100%;
+    color: var(--accent-color);
+    font-size: 13px;
+    font-weight: 700;
+    line-height: normal;
+    text-decoration: none;
+    overflow-wrap: anywhere;
+  }
+
+  .link-icon {
+    display: block;
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .link:hover {
+    text-decoration: underline;
+  }
+
+  .link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent-color) 42%, Canvas);
+    outline-offset: 4px;
+  }
+
+  @media (max-width: 320px) {
+    .prismatic-book-card {
+      height: auto;
+      min-height: 500px;
+    }
+
+    .cover-slot {
+      height: auto;
+      aspect-ratio: 7 / 10;
+    }
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,6 +6,7 @@ export { default as PrismaticGradientButton } from './PrismaticGradientButton.sv
 export { default as PrismaticSectionHeading } from './PrismaticSectionHeading.svelte';
 export { default as PrismaticStoryCard } from './PrismaticStoryCard.svelte';
 export { default as PrismaticWorkCard } from './PrismaticWorkCard.svelte';
+export { default as PrismaticBookCard } from './PrismaticBookCard.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticBookCardWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticBookCardWrapper.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import PrismaticBookCard from '../../lib/PrismaticBookCard.svelte';
+  import { CCLVividColor } from '../../lib/const/config';
+
+  const vividColors = Object.entries(CCLVividColor);
+</script>
+
+<div class="color-palette">
+  {#each vividColors as [name, tone] (name)}
+    <div class="color-sample">
+      <span>{name}</span>
+      <PrismaticBookCard linkLabel={`${name} を見る`} {tone} />
+    </div>
+  {/each}
+</div>
+
+<style>
+  .color-palette {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 24px;
+    width: min(100%, 980px);
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  .color-sample {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .color-sample > span {
+    font-family: Inter, sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+</style>

--- a/src/stories/PrismaticBookCard.stories.ts
+++ b/src/stories/PrismaticBookCard.stories.ts
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import PrismaticBookCard from '$lib/PrismaticBookCard.svelte';
+import { CCLVividColor } from '$lib/const/config';
+import { expect, within } from '@storybook/test';
+import AllColorsPrismaticBookCardWrapper from './AllColors/AllColorsPrismaticBookCardWrapper.svelte';
+import PrismaticBookCardMixedWrapper from './PrismaticBookCardMixedWrapper.svelte';
+
+const toneOptions = [
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.PINEAPPLE_YELLOW,
+  CCLVividColor.SODA_BLUE,
+  CCLVividColor.MELON_GREEN,
+  CCLVividColor.GRAPE_PURPLE,
+  CCLVividColor.WRAP_GREY
+];
+
+const meta = {
+  title: 'CommonComponents/PrismaticBookCard',
+  component: PrismaticBookCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    href: { control: { type: 'text' } },
+    linkLabel: { control: { type: 'text' } },
+    imageUrl: { control: { type: 'text' } },
+    imageAlt: { control: { type: 'text' } },
+    tone: {
+      control: { type: 'select' },
+      options: toneOptions
+    }
+  }
+} satisfies Meta<PrismaticBookCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    href: 'https://example.com',
+    linkLabel: 'READ MORE',
+    tone: CCLVividColor.STRAWBERRY_PINK
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('リンクラベルが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: 'READ MORE' })).toHaveAttribute(
+        'href',
+        'https://example.com'
+      );
+    });
+  }
+};
+
+export const WithImage: Story = {
+  args: {
+    href: 'https://example.com',
+    linkLabel: 'READ MORE',
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'PrismaticBookCardの書影',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('表紙画像にalt属性が設定されていること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'PrismaticBookCardの書影');
+    });
+  }
+};
+
+export const Japanese: Story = {
+  args: {
+    href: 'https://example.com',
+    linkLabel: '書籍の詳細を見る',
+    tone: CCLVividColor.MELON_GREEN
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('日本語リンクラベルが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: '書籍の詳細を見る' })).toBeInTheDocument();
+    });
+  }
+};
+
+export const WithoutLink: Story = {
+  args: {
+    linkLabel: 'COMING SOON',
+    tone: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('href未指定でもラベルが表示されていること', async () => {
+      await expect(canvas.getByText('COMING SOON')).toBeInTheDocument();
+    });
+
+    await step('href未指定ではリンクにならないこと', async () => {
+      await expect(canvas.queryByRole('link', { name: 'COMING SOON' })).not.toBeInTheDocument();
+    });
+  }
+};
+
+export const MixedWithBookCard: Story = {
+  render: () => ({ Component: PrismaticBookCardMixedWrapper }),
+  args: {},
+  parameters: {
+    layout: 'fullscreen'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('新旧BookCardが同時に表示されていること', async () => {
+      await expect(canvas.getByRole('heading', { name: 'PrismaticBookCard' })).toBeInTheDocument();
+      await expect(canvas.getByRole('heading', { name: 'BookCard' })).toBeInTheDocument();
+    });
+  }
+};
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticBookCardWrapper }),
+  args: {},
+  parameters: {
+    layout: 'fullscreen'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('すべてのtone名が表示されていること', async () => {
+      for (const name of Object.keys(CCLVividColor)) {
+        await expect(canvas.getAllByText(name).length).toBeGreaterThan(0);
+      }
+    });
+  }
+};

--- a/src/stories/PrismaticBookCardMixedWrapper.svelte
+++ b/src/stories/PrismaticBookCardMixedWrapper.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import BookCard from '../lib/BookCard.svelte';
+  import PrismaticBookCard from '../lib/PrismaticBookCard.svelte';
+  import { CCLVividColor } from '../lib/const/config';
+</script>
+
+<div class="comparison">
+  <section class="sample">
+    <h2>PrismaticBookCard</h2>
+    <PrismaticBookCard
+      href="https://example.com"
+      linkLabel="READ MORE"
+      imageUrl="thumbnail.png"
+      imageAlt="PrismaticBookCardの書影"
+      tone={CCLVividColor.STRAWBERRY_PINK}
+    />
+  </section>
+
+  <section class="sample">
+    <h2>BookCard</h2>
+    <BookCard
+      title="既存のBookCard"
+      description="説明文を含む既存コンポーネントです。"
+      coverImageUrl="thumbnail.png"
+      altText="既存BookCardの書影"
+      borderColor={CCLVividColor.SODA_BLUE}
+    />
+  </section>
+</div>
+
+<style>
+  .comparison {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 32px;
+    width: min(100%, 760px);
+    padding: 24px;
+    box-sizing: border-box;
+  }
+
+  .sample {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+    min-width: 0;
+  }
+
+  h2 {
+    margin: 0;
+    color: color-mix(in srgb, var(--palette-grape-900) 42%, var(--palette-wrap-900));
+    font-family: Inter, sans-serif;
+    font-size: 18px;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+</style>


### PR DESCRIPTION
## 概要

Issue #87に対応し、Prismatic Designの縦長BookCardを追加しました。Figmaの300×500px構成を基準に、toneごとに表紙グラデーション、枠線、リンク色が切り替わります。

## 変更内容

- `PrismaticBookCard`と公開exportを追加
- 表紙画像／imageスロット、リンク有無、日本語ラベルに対応
- Default、画像、日本語、リンクなし、既存BookCard混在、All ColorsのStorybookを追加

## 確認結果

- `pnpm build-storybook`: 成功
- `pnpm check`: 既存の`dist`・Vite一時ファイル等を含む290件のエラーにより失敗（新規ファイル由来のエラーは確認されず）

## 関連Issue

Closes #87
