### PR TITLE
[Prismatic Design] SiteFooterを実装

### DIFF
--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -1,0 +1,216 @@
+<script context="module" lang="ts">
+  export type PrismaticSiteFooterTone =
+    | '--strawberry-pink'
+    | '--pineapple-yellow'
+    | '--soda-blue'
+    | '--melon-green'
+    | '--grape-purple'
+    | '--wrap-grey';
+
+  export type PrismaticSiteFooterLink = {
+    label: string;
+    href: string;
+  };
+
+  export type PrismaticSiteFooterProps = {
+    brand?: string;
+    brandHref?: string;
+    logoUrl?: string;
+    logoAlt?: string;
+    logoHeight?: string;
+    links?: PrismaticSiteFooterLink[];
+    copyright?: string;
+    ariaLabel?: string;
+    tone?: PrismaticSiteFooterTone;
+  };
+</script>
+
+<script lang="ts">
+  import { CCLVividColor } from './const/config';
+
+  const defaultLinks: PrismaticSiteFooterLink[] = [
+    { label: 'PRIVACY', href: '#privacy' },
+    { label: 'CONTACT', href: '#contact' }
+  ];
+
+  const year = new Date().getFullYear();
+
+  export let brand: string = 'CANDY CHUPS Lab.';
+  export let brandHref: string | undefined = undefined;
+  export let logoUrl: string | undefined = undefined;
+  export let logoAlt: string | undefined = undefined;
+  export let logoHeight: string = '40px';
+  export let links: PrismaticSiteFooterLink[] = defaultLinks;
+  export let copyright: string = `Copyright © ${year} CANDY CHUPS Lab. All Rights Reserved.`;
+  export let ariaLabel: string = 'フッターナビゲーション';
+  export let tone: PrismaticSiteFooterTone = CCLVividColor.STRAWBERRY_PINK;
+
+  function toCssUrl(value: string): string {
+    const escaped = value
+      .replace(/\0/g, '\uFFFD')
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\a ')
+      .replace(/\r/g, '\\d ')
+      .replace(/\f/g, '\\c ');
+
+    return `url("${escaped}")`;
+  }
+
+  $: accentColor = `var(${tone})`;
+  $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
+  $: logoLabel = logoAlt?.trim() || brand;
+</script>
+
+<footer class="prismatic-site-footer" style="--accent-color: {accentColor};">
+  <div class="footer-main">
+    {#if brandHref}
+      <a class="brand" href={brandHref}>
+        {#if logoUrl}
+          <span
+            class="brand-logo"
+            role="img"
+            aria-label={logoLabel}
+            data-logo-url={logoUrl}
+            style="--logo-height: {logoHeight}; --logo-image: {logoImage};"
+          ></span>
+        {:else}
+          {brand}
+        {/if}
+      </a>
+    {:else}
+      <span class="brand">
+        {#if logoUrl}
+          <span
+            class="brand-logo"
+            role="img"
+            aria-label={logoLabel}
+            data-logo-url={logoUrl}
+            style="--logo-height: {logoHeight}; --logo-image: {logoImage};"
+          ></span>
+        {:else}
+          {brand}
+        {/if}
+      </span>
+    {/if}
+
+    {#if links.length > 0}
+      <nav aria-label={ariaLabel}>
+        <ul>
+          {#each links as item (item.href + item.label)}
+            <li><a href={item.href}>{item.label}</a></li>
+          {/each}
+        </ul>
+      </nav>
+    {/if}
+  </div>
+
+  <small>{copyright}</small>
+</footer>
+
+<style>
+  .prismatic-site-footer {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 32px;
+    width: min(100%, 1300px);
+    min-height: 180px;
+    box-sizing: border-box;
+    padding: 40px 48px 32px;
+    border: 1.5px solid color-mix(in srgb, var(--accent-color) 52%, transparent);
+    border-radius: 34px;
+    background: linear-gradient(
+      112deg,
+      color-mix(in srgb, var(--accent-color) 78%, var(--color-surface-glass)) 0%,
+      color-mix(in srgb, var(--accent-color) 42%, var(--color-surface-glass)) 58%,
+      color-mix(in srgb, var(--accent-color) 18%, var(--color-surface-glass)) 100%
+    );
+    box-shadow: 0 16px 20px color-mix(in srgb, var(--palette-grape-900) 18%, transparent);
+    color: var(--palette-grape-900);
+    font-family: Inter, sans-serif;
+    line-height: normal;
+    letter-spacing: 0;
+  }
+
+  .footer-main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 32px;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    color: inherit;
+    font-size: 22px;
+    font-weight: 700;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .brand-logo {
+    display: block;
+    width: min(300px, 48vw);
+    height: var(--logo-height);
+    background: var(--color-surface-glass);
+    -webkit-mask: var(--logo-image) left center / contain no-repeat;
+    mask: var(--logo-image) left center / contain no-repeat;
+  }
+
+  nav {
+    min-width: 0;
+  }
+
+  ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 12px 24px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li a {
+    color: inherit;
+    font-size: 13px;
+    font-weight: 700;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 5px;
+  }
+
+  li a:hover,
+  li a:focus-visible {
+    text-decoration-line: underline;
+  }
+
+  a:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--accent-color) 42%, Canvas);
+    outline-offset: 4px;
+  }
+
+  small {
+    font-size: 10px;
+    font-weight: 500;
+  }
+
+  @media (max-width: 640px) {
+    .prismatic-site-footer {
+      gap: 28px;
+      min-height: 220px;
+      padding: 32px 28px 28px;
+      border-radius: 28px;
+    }
+
+    .footer-main {
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    ul {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,6 +8,7 @@ export { default as PrismaticStoryCard } from './PrismaticStoryCard.svelte';
 export { default as PrismaticWorkCard } from './PrismaticWorkCard.svelte';
 export { default as PrismaticBookCard } from './PrismaticBookCard.svelte';
 export { default as PrismaticSiteHeader } from './PrismaticSiteHeader.svelte';
+export { default as PrismaticSiteFooter } from './PrismaticSiteFooter.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticSiteFooterWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticSiteFooterWrapper.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import PrismaticSiteFooter from '$lib/PrismaticSiteFooter.svelte';
+  import { CCLVividColor } from '$lib/const/config';
+
+  const tones = Object.entries(CCLVividColor);
+</script>
+
+<div class="tone-list">
+  {#each tones as [name, tone]}
+    <section>
+      <h2>{name}</h2>
+      <PrismaticSiteFooter
+        {tone}
+        brandHref="/"
+        logoUrl="candy-chups-lab.svg"
+        logoAlt="CANDY CHUPS Lab."
+      />
+    </section>
+  {/each}
+</div>
+
+<style>
+  .tone-list {
+    display: grid;
+    gap: 32px;
+    padding: 32px;
+  }
+
+  section {
+    display: grid;
+    gap: 12px;
+  }
+
+  h2 {
+    margin: 0;
+    font:
+      700 14px/1.4 Inter,
+      sans-serif;
+  }
+</style>

--- a/src/stories/PrismaticSiteFooter.stories.ts
+++ b/src/stories/PrismaticSiteFooter.stories.ts
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import { expect, within } from '@storybook/test';
+import PrismaticSiteFooter from '$lib/PrismaticSiteFooter.svelte';
+import { CCLVividColor } from '$lib/const/config';
+import AllColorsPrismaticSiteFooterWrapper from './AllColors/AllColorsPrismaticSiteFooterWrapper.svelte';
+import PrismaticSiteFooterMixedWrapper from './PrismaticSiteFooterMixedWrapper.svelte';
+
+const toneOptions = Object.values(CCLVividColor);
+
+const meta = {
+  title: 'CommonComponents/PrismaticSiteFooter',
+  component: PrismaticSiteFooter,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen'
+  },
+  argTypes: {
+    brand: { control: { type: 'text' } },
+    brandHref: { control: { type: 'text' } },
+    logoUrl: { control: { type: 'text' } },
+    logoAlt: { control: { type: 'text' } },
+    logoHeight: { control: { type: 'text' } },
+    links: { control: { type: 'object' } },
+    copyright: { control: { type: 'text' } },
+    ariaLabel: { control: { type: 'text' } },
+    tone: {
+      control: { type: 'select' },
+      options: toneOptions
+    }
+  }
+} satisfies Meta<PrismaticSiteFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    brandHref: '/',
+    logoUrl: 'candy-chups-lab.svg',
+    logoAlt: 'CANDY CHUPS Lab.',
+    logoHeight: '40px',
+    tone: CCLVividColor.STRAWBERRY_PINK
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('白いSVGロゴとコピーライトが表示されていること', async () => {
+      await expect(canvas.getByRole('img', { name: 'CANDY CHUPS Lab.' })).toHaveAttribute(
+        'data-logo-url',
+        'candy-chups-lab.svg'
+      );
+      await expect(canvas.getByText(/Copyright ©/)).toBeInTheDocument();
+    });
+
+    await step('フッターナビゲーションが表示されていること', async () => {
+      await expect(
+        canvas.getByRole('navigation', { name: 'フッターナビゲーション' })
+      ).toBeInTheDocument();
+      await expect(canvas.getByRole('link', { name: 'CONTACT' })).toHaveAttribute(
+        'href',
+        '#contact'
+      );
+    });
+  }
+};
+
+export const CustomContent: Story = {
+  args: {
+    brand: 'キャンディ研究所',
+    brandHref: '/',
+    links: [
+      { label: '作品', href: '#works' },
+      { label: '書籍', href: '#books' },
+      { label: 'お問い合わせ', href: '#contact' }
+    ],
+    copyright: '© 2026 キャンディ研究所',
+    ariaLabel: 'サイト情報',
+    tone: CCLVividColor.MELON_GREEN
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('変更したブランドとコピーライトが反映されていること', async () => {
+      await expect(canvas.getByRole('link', { name: 'キャンディ研究所' })).toHaveAttribute(
+        'href',
+        '/'
+      );
+      await expect(canvas.getByText('© 2026 キャンディ研究所')).toBeInTheDocument();
+    });
+
+    await step('追加したリンクが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: 'お問い合わせ' })).toHaveAttribute(
+        'href',
+        '#contact'
+      );
+    });
+  }
+};
+
+export const MixedWithFooter: Story = {
+  render: () => ({ Component: PrismaticSiteFooterMixedWrapper }),
+  args: {},
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('新旧Footerが同時に表示されていること', async () => {
+      await expect(
+        canvas.getByRole('heading', { name: 'PrismaticSiteFooter' })
+      ).toBeInTheDocument();
+      await expect(canvas.getByRole('heading', { name: 'Footer' })).toBeInTheDocument();
+    });
+  }
+};
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticSiteFooterWrapper }),
+  args: {},
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('すべてのtone名が表示されていること', async () => {
+      for (const name of Object.keys(CCLVividColor)) {
+        await expect(canvas.getByRole('heading', { name })).toBeInTheDocument();
+      }
+    });
+  }
+};

--- a/src/stories/PrismaticSiteFooterMixedWrapper.svelte
+++ b/src/stories/PrismaticSiteFooterMixedWrapper.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import Footer from '$lib/Footer.svelte';
+  import PrismaticSiteFooter from '$lib/PrismaticSiteFooter.svelte';
+</script>
+
+<div class="comparison">
+  <section>
+    <h2>PrismaticSiteFooter</h2>
+    <PrismaticSiteFooter brandHref="/" logoUrl="candy-chups-lab.svg" logoAlt="CANDY CHUPS Lab." />
+  </section>
+  <section>
+    <h2>Footer</h2>
+    <Footer />
+  </section>
+</div>
+
+<style>
+  .comparison {
+    display: grid;
+    gap: 40px;
+    padding: 32px;
+  }
+
+  section {
+    display: grid;
+    gap: 12px;
+  }
+
+  h2 {
+    margin: 0;
+    font:
+      700 16px/1.4 Inter,
+      sans-serif;
+  }
+</style>


### PR DESCRIPTION
## 概要

Issue #89に対応し、Prismatic Design向けのSiteFooterを追加しました。ブランド、可変リンク、コピーライトを横長グラデーション上に配置し、CANDY CHUPS Lab.のSVGロゴを白で表示します。

## 変更内容

- `PrismaticSiteFooter`と公開exportを追加
- ブランドリンク、可変リンク、コピーライト、アクセシブルなナビゲーション名に対応
- 既存カラートークンを使った6種類の`tone`とレスポンシブ表示を実装
- CANDY CHUPS Lab.のSVGロゴを白いCSSマスクとして表示
- Default、主要props変更、既存Footer混在、All ColorsのStorybookを追加

## 確認結果

- `pnpm build-storybook`: 成功
- `pnpm check`: 既存の`dist`とVite timestampファイルの診断中に300秒でタイムアウト（新規Footer由来のエラーは確認されず）

## 関連Issue

Closes #89