### PR TITLE
[Prismatic Design] AmbientGlowを実装

### DIFF
--- a/src/lib/PrismaticAmbientGlow.svelte
+++ b/src/lib/PrismaticAmbientGlow.svelte
@@ -1,0 +1,114 @@
+<script context="module" lang="ts">
+  export type PrismaticAmbientGlowTone =
+    | '--peach-pink'
+    | '--sugar-blue'
+    | '--lemon-yellow'
+    | '--akebi-purple';
+
+  export type PrismaticAmbientGlowSize = 'small' | 'medium' | 'large';
+  export type PrismaticAmbientGlowOpacity = 'subtle' | 'standard' | 'strong';
+  export type PrismaticAmbientGlowBlur = 'soft' | 'medium' | 'diffuse';
+  export type PrismaticAmbientGlowPosition =
+    | 'top-left'
+    | 'top-right'
+    | 'center'
+    | 'bottom-left'
+    | 'bottom-right';
+
+  export type PrismaticAmbientGlowProps = {
+    tone?: PrismaticAmbientGlowTone;
+    size?: PrismaticAmbientGlowSize;
+    opacity?: PrismaticAmbientGlowOpacity;
+    blur?: PrismaticAmbientGlowBlur;
+    position?: PrismaticAmbientGlowPosition;
+  };
+</script>
+
+<script lang="ts">
+  import { CCLPastelColor } from './const/config';
+
+  const sizes: Record<PrismaticAmbientGlowSize, string> = {
+    small: '220px',
+    medium: '380px',
+    large: '620px'
+  };
+
+  const opacities: Record<PrismaticAmbientGlowOpacity, string> = {
+    subtle: '0.28',
+    standard: '0.48',
+    strong: '0.68'
+  };
+
+  const blurs: Record<PrismaticAmbientGlowBlur, string> = {
+    soft: '44px',
+    medium: '76px',
+    diffuse: '112px'
+  };
+
+  export let tone: PrismaticAmbientGlowTone = CCLPastelColor.PEACH_PINK;
+  export let size: PrismaticAmbientGlowSize = 'medium';
+  export let opacity: PrismaticAmbientGlowOpacity = 'standard';
+  export let blur: PrismaticAmbientGlowBlur = 'medium';
+  export let position: PrismaticAmbientGlowPosition = 'center';
+
+  $: glowSize = sizes[size];
+  $: glowOpacity = opacities[opacity];
+  $: glowBlur = blurs[blur];
+</script>
+
+<span
+  class="ambient-glow {position}"
+  aria-hidden="true"
+  data-testid="prismatic-ambient-glow"
+  data-tone={tone}
+  data-size={size}
+  data-opacity={opacity}
+  data-blur={blur}
+  data-position={position}
+  style="--glow-color: var({tone}); --glow-size: {glowSize}; --glow-opacity: {glowOpacity}; --glow-blur: {glowBlur};"
+></span>
+
+<style>
+  .ambient-glow {
+    position: absolute;
+    z-index: 0;
+    display: block;
+    width: var(--glow-size);
+    height: var(--glow-size);
+    border-radius: 50%;
+    background: var(--glow-color);
+    filter: blur(var(--glow-blur));
+    opacity: var(--glow-opacity);
+    pointer-events: none;
+  }
+
+  .top-left {
+    top: 0;
+    left: 0;
+    transform: translate(-35%, -35%);
+  }
+
+  .top-right {
+    top: 0;
+    right: 0;
+    transform: translate(35%, -35%);
+  }
+
+  .center {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .bottom-left {
+    bottom: 0;
+    left: 0;
+    transform: translate(-35%, 35%);
+  }
+
+  .bottom-right {
+    right: 0;
+    bottom: 0;
+    transform: translate(35%, 35%);
+  }
+</style>

--- a/src/lib/PrismaticAmbientGlow.svelte
+++ b/src/lib/PrismaticAmbientGlow.svelte
@@ -56,6 +56,7 @@
   $: glowBlur = blurs[blur];
 </script>
 
+<!-- The containing block should use position: relative and isolation: isolate. -->
 <span
   class="ambient-glow {position}"
   aria-hidden="true"
@@ -71,7 +72,7 @@
 <style>
   .ambient-glow {
     position: absolute;
-    z-index: 0;
+    z-index: -1;
     display: block;
     width: var(--glow-size);
     height: var(--glow-size);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,6 +9,7 @@ export { default as PrismaticWorkCard } from './PrismaticWorkCard.svelte';
 export { default as PrismaticBookCard } from './PrismaticBookCard.svelte';
 export { default as PrismaticSiteHeader } from './PrismaticSiteHeader.svelte';
 export { default as PrismaticSiteFooter } from './PrismaticSiteFooter.svelte';
+export { default as PrismaticAmbientGlow } from './PrismaticAmbientGlow.svelte';
 export { default as Footer } from './Footer.svelte';
 export { default as Thumbnail } from './Thumbnail.svelte';
 export { default as Card } from './Card.svelte';

--- a/src/stories/AllColors/AllColorsPrismaticAmbientGlowWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticAmbientGlowWrapper.svelte
@@ -47,6 +47,7 @@
 
   .sample {
     position: relative;
+    isolation: isolate;
     min-height: 220px;
     overflow: hidden;
     border: 1px solid var(--palette-wrap-200);

--- a/src/stories/AllColors/AllColorsPrismaticAmbientGlowWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticAmbientGlowWrapper.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import PrismaticAmbientGlow from '$lib/PrismaticAmbientGlow.svelte';
+  import { CCLPastelColor } from '$lib/const/config';
+
+  const tones = [
+    ['PEACH_PINK', CCLPastelColor.PEACH_PINK],
+    ['SUGAR_BLUE', CCLPastelColor.SUGAR_BLUE],
+    ['LEMON_YELLOW', CCLPastelColor.LEMON_YELLOW],
+    ['AKEBI_PURPLE', CCLPastelColor.AKEBI_PURPLE]
+  ] as const;
+</script>
+
+<div class="tone-grid">
+  {#each tones as [name, tone]}
+    <section>
+      <h2>{name}</h2>
+      <div class="sample">
+        <PrismaticAmbientGlow {tone} size="small" blur="soft" />
+      </div>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .tone-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+    padding: 32px;
+    background: var(--palette-wrap-50);
+  }
+
+  section {
+    display: grid;
+    gap: 12px;
+  }
+
+  h2 {
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    color: var(--palette-grape-900);
+    font:
+      700 14px/1.4 Inter,
+      sans-serif;
+  }
+
+  .sample {
+    position: relative;
+    min-height: 220px;
+    overflow: hidden;
+    border: 1px solid var(--palette-wrap-200);
+    background: var(--color-surface-glass);
+  }
+</style>

--- a/src/stories/PrismaticAmbientGlow.stories.ts
+++ b/src/stories/PrismaticAmbientGlow.stories.ts
@@ -55,6 +55,12 @@ export const Default: Story = {
       );
     });
 
+    await step('発光表現が通常コンテンツより背面に配置されること', async () => {
+      await expect(getComputedStyle(canvas.getByTestId('prismatic-ambient-glow')).zIndex).toBe(
+        '-1'
+      );
+    });
+
     await step('指定したtoneと調整値が反映されていること', async () => {
       const glow = canvas.getByTestId('prismatic-ambient-glow');
       await expect(glow).toHaveAttribute('data-tone', CCLPastelColor.PEACH_PINK);

--- a/src/stories/PrismaticAmbientGlow.stories.ts
+++ b/src/stories/PrismaticAmbientGlow.stories.ts
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import { expect, within } from '@storybook/test';
+import PrismaticAmbientGlowStage from './PrismaticAmbientGlowStage.svelte';
+import PrismaticAmbientGlowMixedWrapper from './PrismaticAmbientGlowMixedWrapper.svelte';
+import AllColorsPrismaticAmbientGlowWrapper from './AllColors/AllColorsPrismaticAmbientGlowWrapper.svelte';
+import { CCLPastelColor } from '$lib/const/config';
+
+const toneOptions = [
+  CCLPastelColor.PEACH_PINK,
+  CCLPastelColor.SUGAR_BLUE,
+  CCLPastelColor.LEMON_YELLOW,
+  CCLPastelColor.AKEBI_PURPLE
+];
+
+const meta = {
+  title: 'CommonComponents/PrismaticAmbientGlow',
+  component: PrismaticAmbientGlowStage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen'
+  },
+  argTypes: {
+    tone: { control: { type: 'select' }, options: toneOptions },
+    size: { control: { type: 'select' }, options: ['small', 'medium', 'large'] },
+    opacity: {
+      control: { type: 'select' },
+      options: ['subtle', 'standard', 'strong']
+    },
+    blur: { control: { type: 'select' }, options: ['soft', 'medium', 'diffuse'] },
+    position: {
+      control: { type: 'select' },
+      options: ['top-left', 'top-right', 'center', 'bottom-left', 'bottom-right']
+    }
+  }
+} satisfies Meta<PrismaticAmbientGlowStage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    tone: CCLPastelColor.PEACH_PINK,
+    size: 'medium',
+    opacity: 'standard',
+    blur: 'medium',
+    position: 'center'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('発光表現が読み上げ対象外であること', async () => {
+      await expect(canvas.getByTestId('prismatic-ambient-glow')).toHaveAttribute(
+        'aria-hidden',
+        'true'
+      );
+    });
+
+    await step('指定したtoneと調整値が反映されていること', async () => {
+      const glow = canvas.getByTestId('prismatic-ambient-glow');
+      await expect(glow).toHaveAttribute('data-tone', CCLPastelColor.PEACH_PINK);
+      await expect(glow).toHaveAttribute('data-size', 'medium');
+      await expect(glow).toHaveAttribute('data-opacity', 'standard');
+      await expect(glow).toHaveAttribute('data-blur', 'medium');
+    });
+  }
+};
+
+export const StrongTopRight: Story = {
+  args: {
+    tone: CCLPastelColor.AKEBI_PURPLE,
+    size: 'large',
+    opacity: 'strong',
+    blur: 'diffuse',
+    position: 'top-right'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('強い発光と右上配置が反映されていること', async () => {
+      const glow = canvas.getByTestId('prismatic-ambient-glow');
+      await expect(glow).toHaveAttribute('data-opacity', 'strong');
+      await expect(glow).toHaveAttribute('data-position', 'top-right');
+    });
+  }
+};
+
+export const WithWorkCard: Story = {
+  render: () => ({ Component: PrismaticAmbientGlowMixedWrapper }),
+  args: {
+    tone: CCLPastelColor.PEACH_PINK,
+    size: 'medium',
+    opacity: 'standard',
+    blur: 'medium',
+    position: 'center'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('WorkCardと複数の発光表現が同時に表示されていること', async () => {
+      await expect(
+        canvas.getByRole('heading', { name: '発光表現と組み合わせた制作実績' })
+      ).toBeInTheDocument();
+      await expect(canvas.getAllByTestId('prismatic-ambient-glow')).toHaveLength(2);
+    });
+  }
+};
+
+export const AllColors: Story = {
+  render: () => ({ Component: AllColorsPrismaticAmbientGlowWrapper }),
+  args: {
+    tone: CCLPastelColor.PEACH_PINK,
+    size: 'medium',
+    opacity: 'standard',
+    blur: 'medium',
+    position: 'center'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('4種類のtoneが表示されていること', async () => {
+      await expect(canvas.getAllByTestId('prismatic-ambient-glow')).toHaveLength(4);
+      await expect(canvas.getByRole('heading', { name: 'PEACH_PINK' })).toBeInTheDocument();
+      await expect(canvas.getByRole('heading', { name: 'SUGAR_BLUE' })).toBeInTheDocument();
+      await expect(canvas.getByRole('heading', { name: 'LEMON_YELLOW' })).toBeInTheDocument();
+      await expect(canvas.getByRole('heading', { name: 'AKEBI_PURPLE' })).toBeInTheDocument();
+    });
+  }
+};

--- a/src/stories/PrismaticAmbientGlowMixedWrapper.svelte
+++ b/src/stories/PrismaticAmbientGlowMixedWrapper.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import PrismaticAmbientGlow from '$lib/PrismaticAmbientGlow.svelte';
+  import PrismaticWorkCard from '$lib/PrismaticWorkCard.svelte';
+  import { CCLPastelColor, CCLVividColor } from '$lib/const/config';
+</script>
+
+<div class="composition">
+  <PrismaticAmbientGlow
+    tone={CCLPastelColor.SUGAR_BLUE}
+    size="large"
+    opacity="standard"
+    blur="diffuse"
+    position="top-left"
+  />
+  <PrismaticAmbientGlow
+    tone={CCLPastelColor.AKEBI_PURPLE}
+    size="medium"
+    opacity="subtle"
+    blur="medium"
+    position="bottom-right"
+  />
+  <div class="content">
+    <h2>AmbientGlow + WorkCard</h2>
+    <PrismaticWorkCard
+      title="発光表現と組み合わせた制作実績"
+      linkLabel="VIEW PROJECT"
+      tone={CCLVividColor.SODA_BLUE}
+    />
+  </div>
+</div>
+
+<style>
+  .composition {
+    position: relative;
+    min-height: 620px;
+    overflow: hidden;
+    padding: 64px 32px;
+    background: var(--palette-wrap-50);
+  }
+
+  .content {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    justify-items: center;
+    gap: 24px;
+  }
+
+  h2 {
+    margin: 0;
+    color: var(--palette-grape-900);
+    font:
+      700 18px/1.4 Inter,
+      sans-serif;
+  }
+</style>

--- a/src/stories/PrismaticAmbientGlowMixedWrapper.svelte
+++ b/src/stories/PrismaticAmbientGlowMixedWrapper.svelte
@@ -32,6 +32,7 @@
 <style>
   .composition {
     position: relative;
+    isolation: isolate;
     min-height: 620px;
     overflow: hidden;
     padding: 64px 32px;
@@ -39,8 +40,6 @@
   }
 
   .content {
-    position: relative;
-    z-index: 1;
     display: grid;
     justify-items: center;
     gap: 24px;

--- a/src/stories/PrismaticAmbientGlowStage.svelte
+++ b/src/stories/PrismaticAmbientGlowStage.svelte
@@ -23,6 +23,7 @@
 <style>
   .stage {
     position: relative;
+    isolation: isolate;
     display: grid;
     min-height: 440px;
     overflow: hidden;
@@ -31,8 +32,6 @@
   }
 
   p {
-    position: relative;
-    z-index: 1;
     margin: 0;
     color: var(--palette-grape-900);
     font:

--- a/src/stories/PrismaticAmbientGlowStage.svelte
+++ b/src/stories/PrismaticAmbientGlowStage.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import PrismaticAmbientGlow from '$lib/PrismaticAmbientGlow.svelte';
+  import type {
+    PrismaticAmbientGlowBlur,
+    PrismaticAmbientGlowOpacity,
+    PrismaticAmbientGlowPosition,
+    PrismaticAmbientGlowSize,
+    PrismaticAmbientGlowTone
+  } from '$lib/PrismaticAmbientGlow.svelte';
+
+  export let tone: PrismaticAmbientGlowTone;
+  export let size: PrismaticAmbientGlowSize;
+  export let opacity: PrismaticAmbientGlowOpacity;
+  export let blur: PrismaticAmbientGlowBlur;
+  export let position: PrismaticAmbientGlowPosition;
+</script>
+
+<div class="stage">
+  <PrismaticAmbientGlow {tone} {size} {opacity} {blur} {position} />
+  <p>AMBIENT GLOW</p>
+</div>
+
+<style>
+  .stage {
+    position: relative;
+    display: grid;
+    min-height: 440px;
+    overflow: hidden;
+    place-items: center;
+    background: var(--palette-wrap-50);
+  }
+
+  p {
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    color: var(--palette-grape-900);
+    font:
+      700 18px/1.4 Inter,
+      sans-serif;
+  }
+</style>


### PR DESCRIPTION
## 概要

Issue #90に対応し、背景装飾用の`PrismaticAmbientGlow`を追加しました。既存のPastelカラートークンを使い、サイズ、透明度、blur、配置を限定された選択肢から安全に調整できます。

## 変更内容

- `PrismaticAmbientGlow`と公開exportを追加
- Peach / Soda / Lemon / Akebiの4種類の`tone`に対応
- `size`、`opacity`、`blur`、`position`を限定型のpropsとして実装
- `aria-hidden`と`pointer-events: none`で背景装飾として扱えるよう対応
- Default、強調表示、WorkCardとの合成、All ColorsのStorybookを追加

## 確認結果

- `pnpm build-storybook`: 成功
- `pnpm check`: 既存の`dist`とVite timestampファイルの診断中に300秒でタイムアウト（新規AmbientGlow由来のエラーは確認されず）

## 関連Issue

Closes #90