### PR TITLE
npm Trusted Publishingへ移行

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -5,6 +5,7 @@ on:
       - main
 permissions:
   contents: write
+  id-token: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,12 +19,14 @@ jobs:
           version: 10.28.2
 
       - name: Install Node.js
-        # Setup .npmrc file to publish to npm
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.5.1
 
       - name: Install Node Dependencies
         run: pnpm install --frozen-lockfile
@@ -34,5 +37,4 @@ jobs:
       - name: Deploy Package to NPM
         run: npm publish --access public && pnpm semantic-release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

npmパッケージ公開を長期NPM_TOKENからGitHub Actions OIDCによるTrusted Publishingへ移行します。

## 変更内容

- id-token: writeを追加
- Node.js 22.14.0 / npm 11.5.1へ更新
- NPM_TOKEN依存を削除

## npm側の設定

マージ前にcclkit4svelteのTrusted Publisherへ以下を登録してください。

- Provider: GitHub Actions
- Organization or user: reiji1020
- Repository: ccl-component-kit4svelte
- Workflow filename: publish-package.yaml
- Environment: 未指定

## 確認結果

- pnpm exec prettier --check .github/workflows/publish-package.yaml: 成功
- git diff --check: 成功