### PR TITLE
semantic-releaseのnpm二重公開を解消

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -4,7 +4,6 @@
       '@semantic-release/commit-analyzer',
       '@semantic-release/release-notes-generator',
       ['@semantic-release/changelog', { 'changelogFile': 'docs/CHANGELOG.md' }],
-      '@semantic-release/npm',
       ['@semantic-release/git', { 'assets': ['docs/CHANGELOG.md'] }]
     ],
   'branches': ['main']


### PR DESCRIPTION
## 概要

Trusted Publishingによるnpm公開後にsemantic-releaseがNPM_TOKENを検証し、EINVALIDNPMTOKENで失敗する問題を修正します。

## 原因

Workflowのnpm publishに加えて、@semantic-release/npmもnpm公開処理を担当しており、OIDC移行後もNPM_TOKENを要求していました。

## 変更内容

- .releaserc.yamlから@semantic-release/npmを削除
- npm公開をWorkflow内のnpm publishへ一本化
- changelog生成とgit更新処理は維持

## 確認結果

- Prettierチェック: 成功
- git diff --check: 成功
- semantic-release --dry-run --no-ci: 成功
- dry-runでnpmプラグインが読み込まれないことを確認