### PR TITLE
GitHub Release公開時のみnpmパッケージを公開する

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -1,10 +1,10 @@
 name: Publish Package to npmjs
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - published
 permissions:
-  contents: write
+  contents: read
   id-token: write
 jobs:
   build:
@@ -35,6 +35,4 @@ jobs:
         run: pnpm run package
 
       - name: Deploy Package to NPM
-        run: npm publish --access public && pnpm semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## 概要

GitHub Releaseを公開したときだけnpmパッケージを公開するようにworkflowを変更しました。通常の`main`へのmergeではpublish処理が起動しません。

## 変更内容

- `publish-package.yaml`のトリガーを`release: types: [published]`へ変更
- Trusted Publishingに必要な`id-token: write`を維持
- `contents`権限を`write`から`read`へ縮小
- npm公開後の`pnpm semantic-release`を削除し、workflowの責務をnpm公開に限定

## 確認結果

- `pnpm exec prettier --check .github/workflows/publish-package.yaml`: 成功
- `git diff --check`: 成功
- `pnpm check`: タイムアウト・失敗（今回の変更対象外である既存の`dist/`、`public/storybook/`、古いVite timestampファイルが診断対象となり、既存エラーが多数発生）

## 関連Issue

Closes #103
