### PR TITLE
RadioButtonのdisabled Storyの期待値を修正する

### DIFF
--- a/src/stories/RadioButton.stories.ts
+++ b/src/stories/RadioButton.stories.ts
@@ -32,7 +32,8 @@ const createStory = (initialArgs: Story['args']): Story => ({
   },
   play: async ({ args, canvasElement, step }) => {
     const canvas = within(canvasElement);
-    const radio = canvas.getByRole('radio', { hidden: true });
+    const radio = canvas.getByRole('radio', { hidden: true }) as HTMLInputElement;
+    const wasChecked = radio.checked;
 
     await step('初期状態が正しいこと', async () => {
       if (args?.group === args?.value) {
@@ -45,7 +46,11 @@ const createStory = (initialArgs: Story['args']): Story => ({
     await step('クリック操作が正しく行われること', async () => {
       await userEvent.click(radio);
       if (args?.disabled) {
-        await expect(radio).toBeChecked(); // Disabled radio should not change state
+        if (wasChecked) {
+          await expect(radio).toBeChecked();
+        } else {
+          await expect(radio).not.toBeChecked();
+        }
       } else {
         await expect(radio).toBeChecked();
       }


### PR DESCRIPTION
## 概要

RadioButtonのdisabled Storyで、クリック後の期待値を初期checked状態に応じて検証するよう修正しました。

## 変更内容

- クリック前のDOM上のchecked状態を保存
- `Disabled`がクリック後も未選択のままであることを検証
- `DisabledChecked`がクリック後も選択済みのままであることを検証
- disabledではないStoryの既存挙動は維持

## 確認結果

- `pnpm exec prettier --check src/stories/RadioButton.stories.ts`: 成功
- `pnpm build-storybook`: 成功
- Storybook test-runner: RadioButtonの5 Storyすべて成功
  - `Disabled`: 成功
  - `DisabledChecked`: 成功
- Storybook test-runner全体: 172件成功、2件既存失敗
  - `Pagination/MinimalControls`
  - `Alert/Success`
- `pnpm check`: 既存の84 errors / 11 warningsにより失敗
  - RadioButton Storyの既存型エラー2件を含む
  - 今回追加したchecked参照の型エラーは解消済み

## 関連Issue

Closes #104