### PR TITLE
DatePickerのStoryテストを固定日付ベースにする

### DIFF
--- a/src/stories/DatePicker.stories.ts
+++ b/src/stories/DatePicker.stories.ts
@@ -1,11 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import DatePicker from '../lib/DatePicker.svelte';
-import { CCLVividColor, CCLPastelColor } from '../lib/const/config';
-import { expect, fn, userEvent, within } from '@storybook/test';
-import { DateTime } from 'luxon';
+import { CCLVividColor } from '../lib/const/config';
+import { expect, userEvent, within } from '@storybook/test';
 import AllColorsDatePickerWrapper from './AllColors/AllColorsDatePickerWrapper.svelte';
-
-const colorOptions = Object.values(CCLVividColor);
 
 const meta = {
   title: 'Form/DatePicker',
@@ -14,9 +11,6 @@ const meta = {
   argTypes: {
     selectedDate: {
       control: { type: 'date' }
-    },
-    label: {
-      control: { type: 'text' }
     },
     id: {
       control: { type: 'text' }
@@ -27,9 +21,6 @@ const meta = {
     borderColor: {
       control: { type: 'select' },
       options: Object.values(CCLVividColor)
-    },
-    disableBlurClose: {
-      control: { type: 'boolean' }
     }
   }
 } satisfies Meta<DatePicker>;
@@ -37,30 +28,20 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const createStory = (args: Story['args']): Story => ({
-  args: {
-    ...args,
-    disableBlurClose: true // テスト中はblurで閉じないようにする
-  },
+const createStory = (args: NonNullable<Story['args']>): Story => ({
+  args,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByPlaceholderText(args.placeholder || '日付を選択');
 
+    await step('初期状態では日付が未選択であること', async () => {
+      await expect(input).toHaveValue('');
+    });
+
     await step('日付ピッカーが開くこと', async () => {
       await userEvent.click(input);
-      await expect(canvas.getByText(/\d{4}年\d{2}月/)).toBeInTheDocument(); // 例: 2023年10月
-    });
-
-    await step('日付を選択できること', async () => {
-      const today = DateTime.local(); // Luxonを使用して現在の日付を取得
-      const dayOfMonth = today.day;
-      const dayButton = await canvas.findByRole('button', { name: String(dayOfMonth) });
-      await userEvent.click(dayButton);
-      await expect(input).toHaveValue(today.toFormat('yyyy/MM/dd')); // Luxonのフォーマットに合わせる
-    });
-
-    await step('日付ピッカーが閉じること', async () => {
-      await expect(canvas.queryByText(/\d{4}年\d{2}月/)).not.toBeInTheDocument();
+      await expect(canvas.getByRole('button', { name: '前月へ' })).toBeInTheDocument();
+      await expect(canvas.getByRole('button', { name: '次月へ' })).toBeInTheDocument();
     });
   }
 });
@@ -71,20 +52,42 @@ export const Default = createStory({
   borderColor: CCLVividColor.STRAWBERRY_PINK
 });
 
-export const WithInitialDate = createStory({
-  placeholder: '初期日付',
-  selectedDate: new Date('2023-01-15'),
-  borderColor: CCLVividColor.PINEAPPLE_YELLOW
-});
+export const WithInitialDate: Story = {
+  args: {
+    placeholder: '初期日付',
+    selectedDate: new Date(2023, 0, 15),
+    borderColor: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByPlaceholderText('初期日付');
 
-WithInitialDate.play = async ({ canvasElement, step, args }) => {
-  const canvas = within(canvasElement);
-  const input = canvas.getByPlaceholderText(args.placeholder || '初期日付');
+    await step('固定した初期日付が正しく表示されていること', async () => {
+      await expect(input).toHaveValue('2023/01/15');
+    });
 
-  await step('初期日付が正しく表示されていること', async () => {
-    const expectedDate = DateTime.fromJSDate(args.selectedDate as Date).toFormat('yyyy/MM/dd');
-    await expect(input).toHaveValue(expectedDate);
-  });
+    await step('固定した年月のカレンダーが開くこと', async () => {
+      await userEvent.click(input);
+      await expect(canvas.getByText('2023年01月')).toBeInTheDocument();
+    });
+
+    await step('前月と翌月へ移動できること', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: '次月へ' }));
+      await expect(canvas.getByText('2023年02月')).toBeInTheDocument();
+
+      await userEvent.click(canvas.getByRole('button', { name: '前月へ' }));
+      await expect(canvas.getByText('2023年01月')).toBeInTheDocument();
+    });
+
+    await step('固定した日付を選択すると入力値に反映されること', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: '20' }));
+      await expect(input).toHaveValue('2023/01/20');
+    });
+
+    await step('日付選択後にカレンダーが閉じること', async () => {
+      await expect(canvas.queryByText('2023年01月')).not.toBeInTheDocument();
+    });
+  }
 };
 
 export const AllColors: Story = {


### PR DESCRIPTION
## 概要

DatePickerのStoryテストを実行日の現在日付に依存しない固定日付ベースへ変更しました。

## 変更内容

- `DateTime.local()`を使った現在日付依存のテストを削除
- `WithInitialDate`を2023/01/15の固定日付で開始
- 初期日付と表示年月をDOMで検証
- 翌月・前月ボタンによる月移動を検証
- 2023/01/20の選択後、input valueが更新されることを検証
- 日付選択後にカレンダーが閉じることを検証
- DatePickerに存在しない`label`と`disableBlurClose`のStory設定、および未使用importを削除

## 確認結果

- `pnpm exec prettier --check src/stories/DatePicker.stories.ts`: 成功
- `pnpm build-storybook`: 成功
- Storybook test-runner: DatePickerの3 Storyすべて成功
  - `Default`: 成功
  - `WithInitialDate`: 成功
  - `AllColors`: 成功
- Storybook test-runner全体: 172件成功、2件既存失敗
  - `Pagination/MinimalControls`
  - `Alert/Success`
- `pnpm check`: 既存の81 errors / 11 warningsにより失敗
  - DatePicker Story由来の型エラーは0件

## 関連Issue

Closes #106