### PR TITLE
Carouselの前後操作をアクセシブルにしてStoryで検証する

### DIFF
--- a/src/lib/Carousel.svelte
+++ b/src/lib/Carousel.svelte
@@ -44,12 +44,12 @@
 >
   <div class="slides">
     {#each src as item, index}
-      <img class="slide" src={item.src} alt={item.alt} />
+      <img class="slide" src={item.src} alt={item.alt} aria-hidden={index !== currentIndex} />
     {/each}
   </div>
   <div class="buttons">
-    <button on:click={prevSlide}>❮</button>
-    <button on:click={nextSlide}>❯</button>
+    <button type="button" aria-label="前のスライドへ" on:click={prevSlide}>❮</button>
+    <button type="button" aria-label="次のスライドへ" on:click={nextSlide}>❯</button>
   </div>
 </div>
 

--- a/src/stories/Carousel.stories.ts
+++ b/src/stories/Carousel.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Carousel from '$lib/Carousel.svelte';
-import { CCLVividColor } from 'cclkit4svelte';
+import { expect, userEvent, within } from '@storybook/test';
 
 const meta = {
   title: 'CommonComponents/Carousel',
@@ -22,13 +22,42 @@ const createStory = (src: { src: string; alt: string }[], csWidth: string): Stor
   args: {
     src,
     csWidth
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const previousButton = canvas.getByRole('button', { name: '前のスライドへ' });
+    const nextButton = canvas.getByRole('button', { name: '次のスライドへ' });
+    const firstSlide = canvas.getByAltText('カルーセル画像 1');
+    const secondSlide = canvas.getByAltText('カルーセル画像 2');
+
+    await step('前後ボタンをアクセシブルな名前で取得できること', async () => {
+      await expect(previousButton).toBeInTheDocument();
+      await expect(nextButton).toBeInTheDocument();
+    });
+
+    await step('初期状態では最初のスライドが表示対象であること', async () => {
+      await expect(firstSlide).toHaveAttribute('aria-hidden', 'false');
+      await expect(secondSlide).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    await step('次へ操作で次のスライドへ移動すること', async () => {
+      await userEvent.click(nextButton);
+      await expect(firstSlide).toHaveAttribute('aria-hidden', 'true');
+      await expect(secondSlide).toHaveAttribute('aria-hidden', 'false');
+    });
+
+    await step('前へ操作で最初のスライドへ戻ること', async () => {
+      await userEvent.click(previousButton);
+      await expect(firstSlide).toHaveAttribute('aria-hidden', 'false');
+      await expect(secondSlide).toHaveAttribute('aria-hidden', 'true');
+    });
   }
 });
 
 const imageSources = [
-  { src: 'frame1.png', alt: 'alt text' },
-  { src: 'frame2.png', alt: 'alt text' },
-  { src: 'frame3.png', alt: 'alt text' }
+  { src: 'frame1.png', alt: 'カルーセル画像 1' },
+  { src: 'frame2.png', alt: 'カルーセル画像 2' },
+  { src: 'frame3.png', alt: 'カルーセル画像 3' }
 ];
 
 export const Default = createStory(imageSources, '680px');


### PR DESCRIPTION
## 概要

Carouselの前後操作にアクセシブルな名前を付け、Storybookのinteraction testでスライド切り替えを検証できるようにしました。

## 変更内容

- 前へ・次へボタンに`type="button"`と日本語の`aria-label`を追加
- 各画像に現在の表示対象を示す`aria-hidden`を設定
- Storyの画像altをスライドごとに識別可能な内容へ変更
- `Default` Storyで前後ボタンをroleとaccessible nameから取得
- 次へ操作で1枚目から2枚目へ移動することを検証
- 前へ操作で2枚目から1枚目へ戻ることを検証
- 未使用の`CCLVividColor` importを削除

## 確認結果

- `pnpm exec prettier --check src/lib/Carousel.svelte src/stories/Carousel.stories.ts`: 成功
- `pnpm build-storybook`: 成功
- Storybook test-runner: `Carousel/Default`成功
- Storybook test-runner全体: 172件成功、2件既存失敗
  - `Pagination/MinimalControls`
  - `Alert/Success`
- `pnpm check`: 既存の81 errors / 11 warningsにより失敗
  - Carousel本体・Story由来のエラーは0件

## 関連Issue

Closes #105