### PR TITLE
フォーム入力系Storyのdisabledとno-label状態を検証する

### DIFF
--- a/src/stories/Input.stories.ts
+++ b/src/stories/Input.stories.ts
@@ -57,20 +57,51 @@ export const Password = createStory({
   borderColor: CCLVividColor.SODA_BLUE
 });
 
-export const Disabled = createStory({
-  id: 'disabled-input',
-  label: '入力不可',
-  placeholder: 'このフィールドは無効です',
-  value: '編集できません',
-  disabled: true,
-  borderColor: CCLVividColor.WRAP_GREY
-});
+export const Disabled = createStory(
+  {
+    id: 'disabled-input',
+    label: '入力不可',
+    placeholder: 'このフィールドは無効です',
+    value: '編集できません',
+    disabled: true,
+    borderColor: CCLVividColor.WRAP_GREY
+  },
+  async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('入力不可');
 
-export const NoLabel = createStory({
-  id: 'no-label-input',
-  placeholder: 'ラベルなしの入力フィールド',
-  borderColor: CCLVividColor.PINEAPPLE_YELLOW
-});
+    await step('入力フィールドが無効であること', async () => {
+      await expect(input).toBeDisabled();
+      await expect(input).toHaveValue('編集できません');
+    });
+
+    await step('無効な入力フィールドは操作後も値が変わらないこと', async () => {
+      await userEvent.type(input, '変更後の値');
+      await expect(input).toHaveValue('編集できません');
+    });
+  }
+);
+
+export const NoLabel = createStory(
+  {
+    id: 'no-label-input',
+    placeholder: 'ラベルなしの入力フィールド',
+    borderColor: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox');
+
+    await step('ラベルがなくてもplaceholderで入力フィールドを識別できること', async () => {
+      await expect(input).toHaveAttribute('placeholder', 'ラベルなしの入力フィールド');
+    });
+
+    await step('ラベルがない入力フィールドへ入力できること', async () => {
+      await userEvent.type(input, 'ラベルなし入力');
+      await expect(input).toHaveValue('ラベルなし入力');
+    });
+  }
+);
 
 export const Invalid = createStory(
   {

--- a/src/stories/Select.stories.ts
+++ b/src/stories/Select.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Select from '../lib/Select.svelte';
-import { CCLVividColor, CCLPastelColor } from '../lib/const/config';
+import { CCLVividColor } from '../lib/const/config';
 import { expect, userEvent, within } from '@storybook/test';
 import AllColorsSelectWrapper from './AllColors/AllColorsSelectWrapper.svelte';
 
@@ -58,6 +58,20 @@ export const Disabled: Story = {
     value: 'option2',
     disabled: true,
     borderColor: CCLVividColor.WRAP_GREY
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByLabelText('選択不可');
+
+    await step('セレクトボックスが無効であること', async () => {
+      await expect(select).toBeDisabled();
+      await expect(select).toHaveValue('option2');
+    });
+
+    await step('無効なセレクトボックスは操作後も値が変わらないこと', async () => {
+      await userEvent.selectOptions(select, 'option1');
+      await expect(select).toHaveValue('option2');
+    });
   }
 };
 
@@ -67,6 +81,19 @@ export const NoLabel: Story = {
     options: defaultOptions,
     value: 'option3',
     borderColor: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox');
+
+    await step('ラベルがなくてもroleでセレクトボックスを識別できること', async () => {
+      await expect(select).toHaveValue('option3');
+    });
+
+    await step('ラベルがないセレクトボックスでも選択できること', async () => {
+      await userEvent.selectOptions(select, 'option1');
+      await expect(select).toHaveValue('option1');
+    });
   }
 };
 

--- a/src/stories/Textarea.stories.ts
+++ b/src/stories/Textarea.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Textarea from '../lib/Textarea.svelte';
-import { CCLVividColor, CCLPastelColor } from '../lib/const/config';
+import { CCLVividColor } from '../lib/const/config';
 import { expect, userEvent, within } from '@storybook/test';
 import AllColorsTextareaWrapper from './AllColors/AllColorsTextareaWrapper.svelte';
 
@@ -63,6 +63,21 @@ export const Disabled: Story = {
     borderColor: CCLVividColor.WRAP_GREY,
     rows: 7,
     cols: 40
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText('入力不可');
+    const initialValue = '編集できません.\n複数行のテキストです.\n無効化されています.';
+
+    await step('テキストエリアが無効であること', async () => {
+      await expect(textarea).toBeDisabled();
+      await expect(textarea).toHaveValue(initialValue);
+    });
+
+    await step('無効なテキストエリアは操作後も値が変わらないこと', async () => {
+      await userEvent.type(textarea, '変更後の値');
+      await expect(textarea).toHaveValue(initialValue);
+    });
   }
 };
 
@@ -73,6 +88,19 @@ export const NoLabel: Story = {
     borderColor: CCLVividColor.PINEAPPLE_YELLOW,
     rows: 3,
     cols: 25
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+
+    await step('ラベルがなくてもplaceholderでテキストエリアを識別できること', async () => {
+      await expect(textarea).toHaveAttribute('placeholder', 'ラベルなしのテキストエリア');
+    });
+
+    await step('ラベルがないテキストエリアへ入力できること', async () => {
+      await userEvent.type(textarea, 'ラベルなし入力');
+      await expect(textarea).toHaveValue('ラベルなし入力');
+    });
   }
 };
 


### PR DESCRIPTION
## 概要

フォーム入力系コンポーネントのStoryに、disabled状態とラベルなし状態を検証するinteraction testを追加しました。

## 変更内容

- InputのDisabled Storyで、無効状態と操作後も値が変わらないことを検証
- InputのNoLabel Storyで、roleとplaceholderによる識別および入力操作を検証
- SelectのDisabled Storyで、無効状態と選択操作後も値が変わらないことを検証
- SelectのNoLabel Storyで、combobox roleによる識別および選択操作を検証
- TextareaのDisabled Storyで、無効状態と入力操作後も値が変わらないことを検証
- TextareaのNoLabel Storyで、roleとplaceholderによる識別および入力操作を検証
- Select/Textarea Storyの未使用importを削除

## 動作確認

- `pnpm exec prettier --check src/stories/Input.stories.ts src/stories/Select.stories.ts src/stories/Textarea.stories.ts`: 成功
- `pnpm build-storybook`: 成功
- Storybook test-runner: 対象のInput/Select/Textarea Storyはすべて成功
- Storybook test-runner全体: 170 passed / 4 failed（今回未変更のPagination/MinimalControlsおよびAlert/Successに既存失敗あり）
- `pnpm check`: 81 errors / 11 warnings（既存ベースラインと同数。対象ファイルでは既存のInput StoryのvalidationMessage型エラーのみで、今回追加したテストによる新規エラーなし）

Closes #109