### PR TITLE
Button系Storyのargs-only検証をDOM検証へ置き換える

### DIFF
--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Button from '$lib/Button.svelte';
-import { CCLVividColor, CCLPastelColor } from '$lib/const/config';
+import { CCLVividColor } from '$lib/const/config';
 import { expect, fn, userEvent, within } from '@storybook/test';
 import AllColorsButtonWrapper from './AllColors/AllColorsButtonWrapper.svelte';
 
@@ -44,18 +44,16 @@ const createStory = (bgColor: string, label: string, disabled: boolean = false):
   },
   play: async ({ args, canvasElement, step }) => {
     const canvas = within(canvasElement);
-    const button = canvas.getByRole('button');
+    const button = canvas.getByRole('button', { name: label });
 
-    await step('ボタンが存在すること', async () => {
+    await step('ボタンがラベルをaccessible nameとして表示していること', async () => {
       await expect(button).toBeInTheDocument();
+      await expect(button).toHaveAccessibleName(label);
+      await expect(button).toHaveTextContent(label);
     });
 
-    await step('ボタンの色が正しく設定されていること', async () => {
-      await expect(args.bgColor).toBe(bgColor);
-    });
-
-    await step('ボタンのラベルが正しく設定されていること', async () => {
-      await expect(args.label).toBe(label);
+    await step('ボタンの色がCSS custom propertyへ反映されていること', async () => {
+      await expect(button.style.getPropertyValue('--bgColor').trim()).toBe(`var(${bgColor})`);
     });
 
     if (disabled) {

--- a/src/stories/PrismaticGradientButton.stories.ts
+++ b/src/stories/PrismaticGradientButton.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import PrismaticGradientButton from '$lib/PrismaticGradientButton.svelte';
-import { CCLVividColor } from '$lib/const/config';
+import { CCLPastelColor, CCLVividColor } from '$lib/const/config';
 import { expect, fn, userEvent, within } from '@storybook/test';
 import AllColorsPrismaticGradientButtonWrapper from './AllColors/AllColorsPrismaticGradientButtonWrapper.svelte';
 
@@ -52,6 +52,8 @@ const createStory = (
   tone: 'primary' | 'secondary',
   size: 'large' | 'medium',
   color: string,
+  expectedGradientStart: string,
+  expectedGradientEnd: string,
   disabled: boolean = false
 ): Story => ({
   args: {
@@ -67,17 +69,23 @@ const createStory = (
     const canvas = within(canvasElement);
     const button = canvas.getByRole('button', { name: label });
 
-    await step('ボタンが表示されていること', async () => {
+    await step('ボタンがラベルをaccessible nameとして表示していること', async () => {
       await expect(button).toBeInTheDocument();
+      await expect(button).toHaveAccessibleName(label);
+      await expect(button).toHaveTextContent(label);
     });
 
-    await step('ラベルが表示されていること', async () => {
-      await expect(canvas.getByText(label)).toBeInTheDocument();
+    await step('toneとsizeがclassへ反映されていること', async () => {
+      await expect(button).toHaveClass(`tone-${tone}`, `size-${size}`);
     });
 
-    await step('toneとsizeが反映されていること', async () => {
-      await expect(args.tone).toBe(tone);
-      await expect(args.size).toBe(size);
+    await step('色指定がグラデーションのCSS custom propertyへ反映されていること', async () => {
+      await expect(button.style.getPropertyValue('--gradient-start').trim()).toBe(
+        `var(${expectedGradientStart})`
+      );
+      await expect(button.style.getPropertyValue('--gradient-end').trim()).toBe(
+        `var(${expectedGradientEnd})`
+      );
     });
 
     if (disabled) {
@@ -106,13 +114,17 @@ export const Default = createStory(
   'EXPLORE THE LAB',
   'primary',
   'large',
-  CCLVividColor.STRAWBERRY_PINK
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.STRAWBERRY_PINK,
+  CCLVividColor.SODA_BLUE
 );
 
 export const Secondary = createStory(
   'EXPLORE THE LAB',
   'secondary',
   'medium',
+  CCLVividColor.PINEAPPLE_YELLOW,
+  CCLPastelColor.LEMON_YELLOW,
   CCLVividColor.PINEAPPLE_YELLOW
 );
 
@@ -121,6 +133,8 @@ export const Disabled = createStory(
   'secondary',
   'large',
   CCLVividColor.PINEAPPLE_YELLOW,
+  CCLPastelColor.LEMON_YELLOW,
+  CCLPastelColor.PEACH_PINK,
   true
 );
 
@@ -147,7 +161,9 @@ export const AllColors: Story = {
     });
 
     await step('Secondaryの6色が表示されていること', async () => {
-      const secondarySection = canvas.getByRole('heading', { name: 'Secondary' }).closest('section');
+      const secondarySection = canvas
+        .getByRole('heading', { name: 'Secondary' })
+        .closest('section');
 
       await expect(secondarySection).not.toBeNull();
       await expect(within(secondarySection as HTMLElement).getAllByRole('button')).toHaveLength(6);


### PR DESCRIPTION
## 概要

Button系Storyでpropsの入力値だけを確認していたテストを、実際のDOM描画結果を確認するテストへ変更しました。

## 変更内容

- Buttonのラベルをaccessible nameとtext contentで検証
- Buttonの色指定を`--bgColor`のDOM反映で検証
- PrismaticGradientButtonのtone/sizeをclassで検証
- PrismaticGradientButtonの色指定をグラデーション用CSS custom propertyで検証
- disabled属性とクリックcallbackの検証を両コンポーネントで維持

## 確認結果

- `pnpm exec prettier --check src/stories/Button.stories.ts src/stories/PrismaticGradientButton.stories.ts`: 成功
- `pnpm build-storybook`: 成功
- Storybook test-runner: Button 3 StoryとPrismaticGradientButton 4 Storyはすべて成功
- Storybook test-runner全体: 170 passed / 4 failed（今回未変更のPagination/MinimalControlsおよびAlert/Successに既存失敗あり）
- `pnpm check`: 81 errors / 11 warnings（既存ベースラインと同数。今回の変更による新規診断なし）

## 関連Issue

Closes #108