### PR TITLE
Table StoryのplayをDOM検証中心に見直す

### DIFF
--- a/src/stories/Table.stories.ts
+++ b/src/stories/Table.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Table from '$lib/Table.svelte';
-import { CCLVividColor } from '$lib/const/config';
+import { CCLPastelColor, CCLVividColor } from '$lib/const/config';
 import { expect, within } from '@storybook/test';
 
 const colorOptions = [
@@ -30,21 +30,75 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const createStory = (tableColor: string, dataHeader: string[], tableData: string[][]): Story => ({
+const createStory = (
+  tableColor: string,
+  bodyColor: string,
+  dataHeader: string[],
+  tableData: string[][],
+  expectScroll: boolean = false
+): Story => ({
   args: {
     tableColor,
     dataHeader,
     tableData
   },
-  play: async ({ args, step }) => {
-    await step('メインカラーとして指定した色が正しいこと', async () => {
-      await expect(args.tableColor).toBe(tableColor);
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const table = canvas.getByRole('table');
+    const header = table.querySelector('thead') as HTMLElement;
+    const body = table.querySelector('tbody') as HTMLElement;
+    const wrapper = table.closest('.table-wrapper') as HTMLElement;
+    const bodyRows = within(body).getAllByRole('row');
+
+    await step('スクロール用wrapper内にtableが描画されていること', async () => {
+      await expect(wrapper).toHaveClass('table-wrapper');
+      await expect(getComputedStyle(wrapper).overflowY).toBe('auto');
     });
+
+    await step('header cellがStoryデータ通りに描画されていること', async () => {
+      const headerCells = within(header).getAllByRole('columnheader');
+
+      await expect(headerCells).toHaveLength(dataHeader.length);
+      for (const [index, title] of dataHeader.entries()) {
+        await expect(headerCells[index]).toHaveTextContent(title);
+      }
+    });
+
+    await step('body rowとcellがStoryデータ通りに描画されていること', async () => {
+      await expect(bodyRows).toHaveLength(tableData.length);
+
+      for (const [rowIndex, expectedRow] of tableData.entries()) {
+        const cells = within(bodyRows[rowIndex]).getAllByRole('cell');
+
+        await expect(cells).toHaveLength(expectedRow.length);
+        for (const [cellIndex, expectedValue] of expectedRow.entries()) {
+          await expect(cells[cellIndex]).toHaveTextContent(expectedValue);
+        }
+      }
+    });
+
+    await step('色指定とsticky headerがDOMへ反映されていること', async () => {
+      await expect(header.style.getPropertyValue('--bgColor').trim()).toBe(`var(${tableColor})`);
+      await expect(getComputedStyle(header).position).toBe('sticky');
+
+      for (const row of bodyRows) {
+        await expect(row.style.getPropertyValue('--table-body-color').trim()).toBe(
+          `var(${bodyColor})`
+        );
+      }
+    });
+
+    if (expectScroll) {
+      await step('行数が多い場合にwrapper内を縦スクロールできること', async () => {
+        await expect(wrapper.scrollHeight).toBeGreaterThan(wrapper.clientHeight);
+      });
+    }
   }
 });
 
 export const withScroll = createStory(
   CCLVividColor.STRAWBERRY_PINK,
+  CCLPastelColor.PEACH_PINK,
   ['更新日', 'お知らせ内容', 'カテゴリ'],
   [
     [
@@ -75,11 +129,13 @@ export const withScroll = createStory(
     ['2024/03/19', '商業誌出版のお知らせ', '出版物'],
     ['2024/03/19', 'イベント参加のお知らせ', 'イベント'],
     ['2024/03/19', '商業誌出版のお知らせ', '出版物']
-  ]
+  ],
+  true
 );
 
 export const Yellow = createStory(
   CCLVividColor.PINEAPPLE_YELLOW,
+  CCLPastelColor.LEMON_YELLOW,
   ['更新日', 'お知らせ内容', 'カテゴリ'],
   [
     ['2024/03/19', 'イベント参加のお知らせ', 'イベント'],
@@ -91,6 +147,7 @@ export const Yellow = createStory(
 
 export const Blue = createStory(
   CCLVividColor.SODA_BLUE,
+  CCLPastelColor.SUGAR_BLUE,
   ['更新日', 'お知らせ内容', 'カテゴリ'],
   [
     ['2024/03/19', 'イベント参加のお知らせ', 'イベント'],


### PR DESCRIPTION
## 概要

Table Storyのargs-only検証を、実際のtable DOMを確認するinteraction testへ置き換えました。

## 変更内容

- header cellの件数と内容をStoryデータ順に検証
- body row/cellの件数と内容をStoryデータ順に検証
- header/body色のCSS custom propertyとsticky headerを検証
- scroll wrapperのclassとoverflowを検証
- withScrollで実際に縦スクロール可能な寸法を検証

## 確認結果

- `pnpm exec prettier --check src/stories/Table.stories.ts`: 成功
- `pnpm build-storybook`: 成功
- Storybook test-runner: TableのwithScroll/Yellow/Blueはすべて成功
- Storybook test-runner全体: 170 passed / 4 failed（今回未変更のPagination/MinimalControlsおよびAlert/Successに既存失敗あり）
- `pnpm check`: 81 errors / 11 warnings（既存ベースラインと同数。Table Story由来の新規診断なし）

## 関連Issue

Closes #107