### PR TITLE
Svelte 5環境でStorybookの型エラーを解消する

### DIFF
--- a/src/stories/AccordionItem.stories.ts
+++ b/src/stories/AccordionItem.stories.ts
@@ -3,7 +3,7 @@ import AccordionItem from '../lib/AccordionItem.svelte';
 import ItemWrapper from './accordion/ItemWrapper.svelte';
 import { CCLVividColor, CCLPastelColor } from '../lib/const/config';
 
-const colorOptions = { ...CCLVividColor, ...CCLPastelColor };
+const colorOptions = [...Object.values(CCLVividColor), ...Object.values(CCLPastelColor)];
 
 const meta = {
   title: 'CommonComponents/Accordion/AccordionItem',

--- a/src/stories/Alert.stories.ts
+++ b/src/stories/Alert.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Alert from '../lib/Alert.svelte';
-import { expect, fn, userEvent, within } from '@storybook/test';
+import AlertDismissWrapper from './AlertDismissWrapper.svelte';
+import { expect, userEvent, within } from '@storybook/test';
 
 const meta = {
   title: 'CommonComponents/Alert',
@@ -19,8 +20,7 @@ const meta = {
     },
     outline: {
       control: { type: 'boolean' }
-    },
-    onDismiss: { action: 'dismiss' }
+    }
   }
 } satisfies Meta<Alert>;
 
@@ -28,6 +28,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Success: Story = {
+  render: (args) => ({ Component: AlertDismissWrapper, props: args }),
   args: {
     message: '操作が正常に完了しました。',
     type: 'success',
@@ -44,10 +45,10 @@ export const Success: Story = {
         await expect(dismissButton).toBeInTheDocument();
       });
 
-      await step('閉じるボタンをクリックするとonDismissイベントが発火すること', async () => {
+      await step('閉じるボタンをクリックするとdismissイベントが発火すること', async () => {
         const dismissButton = canvas.getByLabelText('Dismiss alert');
         await userEvent.click(dismissButton);
-        await expect(args.onDismiss).toHaveBeenCalled();
+        await expect(canvas.getByTestId('dismiss-status')).toHaveTextContent('dismissed');
       });
     }
   }

--- a/src/stories/AlertDismissWrapper.svelte
+++ b/src/stories/AlertDismissWrapper.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import Alert from '../lib/Alert.svelte';
+
+  export let message: string;
+  export let type: 'success' | 'error' | 'warning' | 'info' = 'info';
+  export let dismissible: boolean = false;
+  export let outline: boolean = false;
+
+  let dismissed = false;
+</script>
+
+<Alert {message} {type} {dismissible} {outline} on:dismiss={() => (dismissed = true)} />
+<output data-testid="dismiss-status">{dismissed ? 'dismissed' : 'active'}</output>

--- a/src/stories/AllColors/AllColorsBadgeWrapper.svelte
+++ b/src/stories/AllColors/AllColorsBadgeWrapper.svelte
@@ -8,7 +8,7 @@
   <div class="color-grid">
     {#each Object.entries(CCLVividColor) as [name, color]}
       <div class="color-sample">
-        <Badge {color} variant="solid" size="md" label={name} />
+        <Badge {color} variant="solid" size="md" label={name} ariaLabel={name} />
       </div>
     {/each}
   </div>
@@ -17,7 +17,7 @@
   <div class="color-grid">
     {#each Object.entries(CCLPastelColor) as [name, color]}
       <div class="color-sample">
-        <Badge {color} variant="solid" size="md" label={name} />
+        <Badge {color} variant="solid" size="md" label={name} ariaLabel={name} />
       </div>
     {/each}
   </div>
@@ -26,7 +26,7 @@
   <div class="color-grid">
     {#each Object.entries(CCLVividColor) as [name, color]}
       <div class="color-sample">
-        <Badge {color} variant="outline" size="md" label={name} />
+        <Badge {color} variant="outline" size="md" label={name} ariaLabel={name} />
       </div>
     {/each}
   </div>
@@ -35,7 +35,7 @@
   <div class="color-grid">
     {#each Object.entries(CCLPastelColor) as [name, color]}
       <div class="color-sample">
-        <Badge {color} variant="outline" size="md" label={name} />
+        <Badge {color} variant="outline" size="md" label={name} ariaLabel={name} />
       </div>
     {/each}
   </div>

--- a/src/stories/AllColors/AllColorsCommonHeaderWrapper.svelte
+++ b/src/stories/AllColors/AllColorsCommonHeaderWrapper.svelte
@@ -13,6 +13,7 @@
           height={HeaderHeight.NORMAL}
           logo="beace.svg"
           logoHeight="50px"
+          href="/"
         />
         <span>{name}</span>
       </div>
@@ -28,6 +29,7 @@
           height={HeaderHeight.NORMAL}
           logo="beace.svg"
           logoHeight="50px"
+          href="/"
         />
         <span>{name}</span>
       </div>

--- a/src/stories/AllColors/AllColorsDialogWrapper.svelte
+++ b/src/stories/AllColors/AllColorsDialogWrapper.svelte
@@ -3,7 +3,8 @@
   import Button from '../../lib/Button.svelte';
   import { CCLVividColor, CCLPastelColor } from '../../lib/const/config';
 
-  type Entry = { name: string; color: string; open: boolean };
+  type VividVar = (typeof CCLVividColor)[keyof typeof CCLVividColor];
+  type Entry = { name: string; color: VividVar; open: boolean };
   let vividEntries: Entry[] = Object.entries(CCLVividColor).map(([name, color]) => ({
     name,
     color,

--- a/src/stories/AllColors/AllColorsProgressBarWrapper.svelte
+++ b/src/stories/AllColors/AllColorsProgressBarWrapper.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import ProgressBar from '../../lib/ProgressBar.svelte';
-  import { CCLVividColor, CCLPastelColor } from '../../lib/const/config';
+  import { CCLVividColor, CCLPastelColor, ProgressBarHeight } from '../../lib/const/config';
 
   const vividColors = [
     { name: 'STRAWBERRY_PINK', bar: CCLVividColor.STRAWBERRY_PINK, bg: CCLPastelColor.PEACH_PINK },
@@ -39,7 +39,7 @@
             barColor={colorOption.bar}
             backgroundColor={colorOption.bg}
             containerWidth="100%"
-            height="20px"
+            height={ProgressBarHeight.WIDE}
           />
           <span style="font-size: 14px; color: #555;">{colorOption.name}</span>
         </div>
@@ -60,7 +60,7 @@
             barColor={colorOption.bar}
             backgroundColor={colorOption.bg}
             containerWidth="100%"
-            height="20px"
+            height={ProgressBarHeight.WIDE}
           />
           <span style="font-size: 14px; color: #555;">{colorOption.name}</span>
         </div>

--- a/src/stories/AllColors/AllColorsSelectWrapper.svelte
+++ b/src/stories/AllColors/AllColorsSelectWrapper.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import Select from '../../lib/Select.svelte';
-  import type { SelectOption } from '../lib/Select.svelte';
   import { CCLVividColor, CCLPastelColor } from '../../lib/const/config';
+
+  type SelectOption = { value: string; label: string };
 
   const options: SelectOption[] = [
     { value: 'option1', label: 'オプション 1' },

--- a/src/stories/Badge.stories.ts
+++ b/src/stories/Badge.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/svelte';
 import { expect, within } from '@storybook/test';
 import Badge from '$lib/Badge.svelte';
 import { CCLVividColor, CCLPastelColor } from '$lib/const/config';
+import type { ColorVar } from '$lib/const/config';
 import AllColorsBadgeWrapper from './AllColors/AllColorsBadgeWrapper.svelte';
 
 const colorOptions = [...Object.values(CCLVividColor), ...Object.values(CCLPastelColor)];
@@ -32,12 +33,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const createStory = (
-  color: string,
+  color: ColorVar,
   variant: 'solid' | 'outline',
   size: 'sm' | 'md' | 'lg',
   label: string
 ): Story => ({
-  args: { color, variant, size, label },
+  args: { color, variant, size, label, ariaLabel: label },
   play: async ({ args, canvasElement, step }) => {
     const canvas = within(canvasElement);
     await step('バッジのテキストが表示されていること', async () => {
@@ -51,7 +52,9 @@ const createStory = (
       await expect(host).toHaveAttribute('data-size', size);
     });
     await step('色プロパティが設定されていること', async () => {
-      await expect(args.color).toBe(color);
+      const el = await canvas.findByText(label);
+      const host = el.closest('.ccl-badge') as HTMLElement;
+      await expect(host.style.getPropertyValue('--badge-color').trim()).toBe(`var(${color})`);
     });
   }
 });
@@ -61,7 +64,13 @@ export const Default: Story = createStory(CCLVividColor.SODA_BLUE, 'solid', 'md'
 export const Outline: Story = createStory(CCLVividColor.STRAWBERRY_PINK, 'outline', 'md', 'Beta');
 
 export const LargePastel: Story = {
-  args: { color: CCLPastelColor.LEMON_YELLOW, variant: 'solid', size: 'lg', label: 'Featured' },
+  args: {
+    color: CCLPastelColor.LEMON_YELLOW,
+    variant: 'solid',
+    size: 'lg',
+    label: 'Featured',
+    ariaLabel: 'Featured'
+  },
   play: async ({ args, canvasElement, step }) => {
     const canvas = within(canvasElement);
     await step('バッジのテキストが表示されていること', async () => {
@@ -84,7 +93,7 @@ export const LargePastel: Story = {
 
 export const AllColors: Story = {
   render: () => ({ Component: AllColorsBadgeWrapper }),
-  args: {},
+  args: { label: 'Color sample', ariaLabel: 'Color sample' },
   parameters: {
     docs: {
       source: { code: null }

--- a/src/stories/BookCard.stories.ts
+++ b/src/stories/BookCard.stories.ts
@@ -134,7 +134,12 @@ export const NoLink: Story = {
 
 export const AllColors: Story = {
   render: () => ({ Component: AllColorsBookCardWrapper }),
-  args: {},
+  args: {
+    title: 'Color sample',
+    description: 'BookCard color sample',
+    coverImageUrl: 'thumbnail.png',
+    altText: 'BookCard color sample'
+  },
   parameters: {
     docs: {
       source: {

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Button from '$lib/Button.svelte';
 import { CCLVividColor } from '$lib/const/config';
+import type { ColorVar } from '$lib/const/config';
 import { expect, fn, userEvent, within } from '@storybook/test';
 import AllColorsButtonWrapper from './AllColors/AllColorsButtonWrapper.svelte';
 
@@ -35,7 +36,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const createStory = (bgColor: string, label: string, disabled: boolean = false): Story => ({
+const createStory = (bgColor: ColorVar, label: string, disabled: boolean = false): Story => ({
   args: {
     bgColor,
     label,

--- a/src/stories/ChangeHistory.stories.ts
+++ b/src/stories/ChangeHistory.stories.ts
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import ChangeHistory from '$lib/ChangeHistory.svelte';
-import type { HistoryItem } from '$lib/ChangeHistory.svelte';
+import type { ComponentProps } from 'svelte';
 import { CCLVividColor } from '$lib/const/config';
+
+type HistoryItem = NonNullable<ComponentProps<ChangeHistory>['historyItems']>[number];
 
 const meta: Meta<ChangeHistory> = {
   title: 'CommonComponents/ChangeHistory',

--- a/src/stories/CommonHeader.stories.ts
+++ b/src/stories/CommonHeader.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/svelte';
 import { expect, within } from '@storybook/test';
 import CommonHeader from '$lib/CommonHeader.svelte';
 import { CCLVividColor, CCLPastelColor, HeaderHeight } from '$lib/const/config';
+import type { ColorVar } from '$lib/const/config';
 import AllColorsCommonHeaderWrapper from './AllColors/AllColorsCommonHeaderWrapper.svelte';
 
 const colorOptions = [
@@ -41,7 +42,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const createStory = (
-  bgColor: string,
+  bgColor: ColorVar,
   height: string,
   logo: string,
   logoHeight: string,
@@ -91,7 +92,7 @@ export const NallowHeader = createStory(
 
 export const AllColors: Story = {
   render: () => ({ Component: AllColorsCommonHeaderWrapper }),
-  args: {},
+  args: { logo: 'logo.png', logoHeight: '40px', href: '/' },
   parameters: {
     docs: {
       source: {

--- a/src/stories/Footer.stories.ts
+++ b/src/stories/Footer.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import Footer from '$lib/Footer.svelte';
 import { CCLVividColor } from '$lib/const/config';
+import type { ColorVar } from '$lib/const/config';
 import { expect } from '@storybook/test';
 import AllColorsFooterWrapper from './AllColors/AllColorsFooterWrapper.svelte';
 
@@ -31,7 +32,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const createStory = (bgColor: string): Story => ({
+const createStory = (bgColor: ColorVar): Story => ({
   args: {
     bgColor
   },

--- a/src/stories/FormGroup.stories.ts
+++ b/src/stories/FormGroup.stories.ts
@@ -1,14 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
-import FormGroup from '../lib/FormGroup.svelte';
-import Input from '../lib/Input.svelte';
-import Checkbox from '../lib/Checkbox.svelte';
+import FormGroupInputWrapper from './FormGroupInputWrapper.svelte';
 import RegistrationFormWrapper from './RegistrationFormWrapper.svelte';
 import TermsOfServiceFormWrapper from './TermsOfServiceFormWrapper.svelte';
-import { expect, fn, userEvent, within } from '@storybook/test';
+import { expect, userEvent, within } from '@storybook/test';
 
 const meta = {
   title: 'Form/FormGroup',
-  component: FormGroup,
+  component: FormGroupInputWrapper,
   tags: ['autodocs'],
   argTypes: {
     label: { control: 'text' },
@@ -16,11 +14,9 @@ const meta = {
     errorMessage: { control: 'text' },
     forId: { control: 'text' },
     // Inputコンポーネントの値を制御するためのargType
-    value: { control: 'text' },
-    // Checkboxコンポーネントのチェック状態を制御するためのargType
-    checked: { control: 'boolean' }
+    value: { control: 'text' }
   }
-} satisfies Meta<FormGroup>;
+} satisfies Meta<FormGroupInputWrapper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -32,13 +28,7 @@ export const Default: Story = {
     forId: 'username-input',
     value: '' // 初期値を設定
   },
-  render: (args) => ({
-    Component: FormGroup,
-    props: args,
-    template: `<FormGroup label="${args.label}" helpText="${args.helpText}" errorMessage="${args.errorMessage}" forId="${args.forId}">
-						<Input type="text" id="${args.forId}" bind:value={${JSON.stringify(args.value)}} />
-					</FormGroup>`
-  })
+  render: (args) => ({ Component: FormGroupInputWrapper, props: args })
 };
 
 export const RegistrationFormExample: Story = {

--- a/src/stories/FormGroupInputWrapper.svelte
+++ b/src/stories/FormGroupInputWrapper.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import FormGroup from '../lib/FormGroup.svelte';
+  import Input from '../lib/Input.svelte';
+
+  export let label: string = '';
+  export let helpText: string = '';
+  export let errorMessage: string = '';
+  export let forId: string = 'form-group-input';
+  export let value: string = '';
+</script>
+
+<FormGroup {label} {helpText} {errorMessage} {forId}>
+  <Input type="text" id={forId} bind:value />
+</FormGroup>

--- a/src/stories/Header.stories.ts
+++ b/src/stories/Header.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/svelte';
 import { expect, within } from '@storybook/test';
 import Header from '$lib/Header.svelte';
 import { CCLVividColor, CCLPastelColor, HeaderHeight } from '$lib/const/config';
+import type { ColorVar } from '$lib/const/config';
 import AllColorsHeaderWrapper from './AllColors/AllColorsHeaderWrapper.svelte';
 
 const colorOptions = [
@@ -37,7 +38,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const createStory = (bgColor: string, height: string): Story => ({
+const createStory = (bgColor: ColorVar, height: string): Story => ({
   args: {
     bgColor,
     height

--- a/src/stories/HeaderWithDrawer.stories.ts
+++ b/src/stories/HeaderWithDrawer.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import { within, userEvent, expect } from '@storybook/test';
-import Header from '$lib/Header.svelte';
 import { CCLVividColor, HeaderHeight } from '$lib/const/config';
 import HeaderWithDrawerWrapper from './HeaderWithDrawerWrapper.svelte';
 
@@ -17,7 +16,7 @@ const heightOptions = [HeaderHeight.NALLOW, HeaderHeight.NORMAL, HeaderHeight.WI
 
 const meta = {
   title: 'Compositions/HeaderWithDrawer',
-  component: Header,
+  component: HeaderWithDrawerWrapper,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },
   argTypes: {
@@ -26,7 +25,7 @@ const meta = {
     side: { control: { type: 'radio' }, options: ['left', 'right', 'top', 'bottom'] },
     size: { control: { type: 'text' } }
   }
-} satisfies Meta<Header>;
+} satisfies Meta<HeaderWithDrawerWrapper>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/src/stories/HeaderWithDrawerWrapper.svelte
+++ b/src/stories/HeaderWithDrawerWrapper.svelte
@@ -2,8 +2,9 @@
   import Header from '$lib/Header.svelte';
   import SlideMenu from '$lib/SlideMenu.svelte';
   import { CCLVividColor, HeaderHeight } from '$lib/const/config';
+  import type { ColorVar } from '$lib/const/config';
 
-  export let bgColor: string = CCLVividColor.STRAWBERRY_PINK;
+  export let bgColor: ColorVar = CCLVividColor.STRAWBERRY_PINK;
   export let height: string = HeaderHeight.NORMAL;
   export let side: 'left' | 'right' | 'top' | 'bottom' = 'left';
   export let size: string = '320px';

--- a/src/stories/Input.stories.ts
+++ b/src/stories/Input.stories.ts
@@ -118,7 +118,7 @@ export const Invalid = createStory(
     const input = canvas.getByLabelText('メールアドレス');
 
     await step('バリデーションメッセージが正しく表示されること', async () => {
-      const validationMessage = canvas.getByText(args.validationMessage);
+      const validationMessage = canvas.getByText(args.validationMessage ?? '');
       await expect(validationMessage).toBeInTheDocument();
     });
 

--- a/src/stories/PrismaticGradientButton.stories.ts
+++ b/src/stories/PrismaticGradientButton.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import PrismaticGradientButton from '$lib/PrismaticGradientButton.svelte';
 import { CCLPastelColor, CCLVividColor } from '$lib/const/config';
+import type { ColorVar } from '$lib/const/config';
 import { expect, fn, userEvent, within } from '@storybook/test';
 import AllColorsPrismaticGradientButtonWrapper from './AllColors/AllColorsPrismaticGradientButtonWrapper.svelte';
 
@@ -51,7 +52,7 @@ const createStory = (
   label: string,
   tone: 'primary' | 'secondary',
   size: 'large' | 'medium',
-  color: string,
+  color: ColorVar,
   expectedGradientStart: string,
   expectedGradientEnd: string,
   disabled: boolean = false

--- a/src/stories/PrismaticSectionHeading.stories.ts
+++ b/src/stories/PrismaticSectionHeading.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import PrismaticSectionHeading from '$lib/PrismaticSectionHeading.svelte';
+import type { PrismaticSectionHeadingTone } from '$lib/PrismaticSectionHeading.svelte';
 import { CCLVividColor } from '$lib/const/config';
 import { expect, within } from '@storybook/test';
 import AllColorsPrismaticSectionHeadingWrapper from './AllColors/AllColorsPrismaticSectionHeadingWrapper.svelte';
@@ -37,7 +38,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const createStory = (eyebrow: string, title: string, tone: string): Story => ({
+const createStory = (eyebrow: string, title: string, tone: PrismaticSectionHeadingTone): Story => ({
   args: {
     eyebrow,
     title,

--- a/src/stories/PrismaticStoryCard.stories.ts
+++ b/src/stories/PrismaticStoryCard.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
 import PrismaticStoryCard from '$lib/PrismaticStoryCard.svelte';
+import type { PrismaticStoryCardTone } from '$lib/PrismaticStoryCard.svelte';
 import { CCLVividColor } from '$lib/const/config';
 import { expect, within } from '@storybook/test';
 import AllColorsPrismaticStoryCardWrapper from './AllColors/AllColorsPrismaticStoryCardWrapper.svelte';
@@ -60,7 +61,7 @@ type Story = StoryObj<typeof meta>;
 const createStory = (
   title: string,
   size: 'featured' | 'default',
-  tone: string,
+  tone: PrismaticStoryCardTone,
   label?: string,
   href?: string
 ): Story => ({

--- a/src/stories/ProgressBar.stories.ts
+++ b/src/stories/ProgressBar.stories.ts
@@ -86,7 +86,7 @@ export const Default: Story = {
     });
 
     await step('バーの幅(%)が正しく計算されてstyleに適用されていること', async () => {
-      const expectedProgress = (args.value / args.maxValue) * 100;
+      const expectedProgress = ((args.value ?? 0) / (args.maxValue ?? 100)) * 100;
       await expect(progressBar.style.width).toBe(`${expectedProgress}%`);
     });
   }
@@ -154,7 +154,7 @@ export const FullProgress: Story = {
     });
 
     await step('バーの幅(%)が正しく計算されてstyleに適用されていること', async () => {
-      const expectedProgress = (args.value / args.maxValue) * 100;
+      const expectedProgress = ((args.value ?? 0) / (args.maxValue ?? 100)) * 100;
       await expect(progressBar.style.width).toBe(`${expectedProgress}%`);
     });
   }

--- a/src/stories/RadioButton.stories.ts
+++ b/src/stories/RadioButton.stories.ts
@@ -85,6 +85,7 @@ export const MultipleRadioButtons: Story = {
       selectedValue: 'option1'
     }
   }),
+  args: { value: 'option1', group: 'option1' },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
@@ -123,7 +124,7 @@ export const MultipleRadioButtons: Story = {
 
 export const AllColors: Story = {
   render: () => ({ Component: AllColorsRadioButtonWrapper }),
-  args: {},
+  args: { value: 'sample', group: 'sample' },
   parameters: {
     docs: {
       source: {

--- a/src/stories/ServiceCard.stories.ts
+++ b/src/stories/ServiceCard.stories.ts
@@ -131,7 +131,12 @@ NoLink.storyName = 'NoLink';
 
 export const AllColors: Story = {
   render: () => ({ Component: AllColorsServiceCardWrapper }),
-  args: {},
+  args: {
+    serviceName: 'Color sample',
+    description: 'ServiceCard color sample',
+    imageUrl: 'thumbnail.png',
+    altText: 'ServiceCard color sample'
+  },
   parameters: {
     docs: {
       source: {

--- a/src/stories/SlideMenuWrapper.svelte
+++ b/src/stories/SlideMenuWrapper.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import SlideMenu from '$lib/SlideMenu.svelte';
   import { CCLVividColor } from '$lib/const/config';
+  import type { ColorVar } from '$lib/const/config';
 
   export let side: 'left' | 'right' = 'left';
   export let size: string = '320px';
@@ -8,7 +9,7 @@
   export let ariaLabel: string = 'メインメニュー';
   export let items: { id: string; label: string; href?: string }[] = [];
   export let currentId: string | undefined = undefined;
-  export let accentColor: string = CCLVividColor.SODA_BLUE;
+  export let accentColor: ColorVar = CCLVividColor.SODA_BLUE;
 
   let open = false;
   const openMenu = () => (open = true);

--- a/src/stories/TermsOfServiceFormWrapper.svelte
+++ b/src/stories/TermsOfServiceFormWrapper.svelte
@@ -18,8 +18,8 @@
     これはダミーのテキストです。
   </p>
 
-  <FormGroup forId="terms-agree">
-    <Checkbox label="利用規約に同意する" id="terms-agree" bind:checked={agreedToTerms} />
+  <FormGroup>
+    <Checkbox label="利用規約に同意する" bind:checked={agreedToTerms} />
   </FormGroup>
 
   <Button

--- a/src/stories/Thumbnail.stories.ts
+++ b/src/stories/Thumbnail.stories.ts
@@ -66,7 +66,12 @@ export const Default = createStory(
 
 export const AllColors: Story = {
   render: () => ({ Component: AllColorsThumbnailWrapper }),
-  args: {},
+  args: {
+    imageSize: '120px',
+    borderColor: CCLVividColor.STRAWBERRY_PINK,
+    src: 'thumbnail.png',
+    altText: 'Thumbnail color sample'
+  },
   parameters: {
     docs: {
       source: {

--- a/src/stories/Toaster.stories.ts
+++ b/src/stories/Toaster.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/svelte';
-import { within, expect } from '@storybook/test';
+import { within, expect, userEvent } from '@storybook/test';
 import Toaster from '$lib/Toaster.svelte';
 import { toast } from '$lib/index';
 import ToasterPlayground from './ToasterPlayground.svelte';
@@ -18,17 +18,12 @@ const meta = {
     maxVisible: {
       control: { type: 'number', min: 1, max: 10 },
       description: '同時に画面上に表示する最大数',
-      table: { category: 'Behavior', defaultValue: { summary: 5 } }
-    },
-    defaultDuration: {
-      control: { type: 'number', min: 0, step: 100 },
-      description: '個別指定がないときの自動消滅時間 (ms)。0 を指定すると自動消滅しない',
-      table: { category: 'Behavior', defaultValue: { summary: 3000 } }
+      table: { category: 'Behavior', defaultValue: { summary: '5' } }
     },
     dismissible: {
       control: { type: 'boolean' },
       description: '閉じる（×）ボタンを表示するかどうか',
-      table: { category: 'Behavior', defaultValue: { summary: true } }
+      table: { category: 'Behavior', defaultValue: { summary: 'true' } }
     },
     // 直接表示のための入力（Toaster に props で渡す）
     message: {
@@ -58,11 +53,18 @@ export const Default: Story = {
   args: {
     position: 'top-right',
     maxVisible: 5,
-    defaultDuration: 3000,
     dismissible: true,
     message: 'Hello',
     variant: 'info',
     duration: 0
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('デフォルトのトーストが表示されること', async () => {
+      const status = await canvas.findByRole('status');
+      await expect(status).toHaveTextContent('Hello');
+    });
+    toast.clear();
   },
   parameters: {
     docs: {
@@ -72,7 +74,7 @@ export const Default: Story = {
   import { Toaster } from 'cclkit4svelte';
 </script>
 
-<Toaster position="top-right" maxVisible={5} defaultDuration={3000} dismissible message="Hello" variant="info" duration={0} />
+<Toaster position="top-right" maxVisible={5} dismissible message="Hello" variant="info" duration={0} />
         `.trim()
       }
     }
@@ -84,17 +86,17 @@ export const AutoDismiss: Story = {
   args: {
     position: 'top-right',
     maxVisible: 5,
-    defaultDuration: 800,
     dismissible: false,
     message: 'Auto dismiss in 800ms',
-    variant: 'info'
+    variant: 'info',
+    duration: 800
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    await step('defaultDuration で自動消滅すること', async () => {
+    await step('duration で自動消滅すること', async () => {
       // グローバルストアをクリーンにしてから、このストーリーのトーストを発火
       toast.clear();
-      toast.show({ message: 'Auto dismiss in 800ms', variant: 'info' });
+      toast.show({ message: 'Auto dismiss in 800ms', variant: 'info', duration: 800 });
       const status = await canvas.findByRole('status');
       await expect(status).toBeInTheDocument();
     });
@@ -103,7 +105,7 @@ export const AutoDismiss: Story = {
     docs: {
       source: {
         code: `
-<Toaster position="top-right" defaultDuration={800} message="Auto dismiss in 800ms" variant="info" />
+<Toaster position="top-right" message="Auto dismiss in 800ms" variant="info" duration={800} />
         `.trim()
       }
     }
@@ -115,10 +117,18 @@ export const CustomMessage: Story = {
   args: {
     position: 'top-right',
     maxVisible: 5,
-    defaultDuration: 3000,
     variant: 'info',
     message: 'Type your message here',
     duration: 3000
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('Controlsの内容でトーストを表示できること', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'Show Toast' }));
+      const status = await canvas.findByRole('status');
+      await expect(status).toHaveTextContent('Type your message here');
+    });
+    toast.clear();
   },
   argTypes: {
     variant: {
@@ -140,7 +150,7 @@ export const CustomMessage: Story = {
   },
   parameters: {
     controls: {
-      include: ['position', 'maxVisible', 'defaultDuration', 'variant', 'message', 'duration']
+      include: ['position', 'maxVisible', 'variant', 'message', 'duration']
     }
   }
 };
@@ -154,7 +164,6 @@ function makeVariantStory(
     args: {
       position: 'top-right',
       maxVisible: 5,
-      defaultDuration: 3000,
       dismissible: true,
       message,
       variant,
@@ -178,7 +187,7 @@ function makeVariantStory(
   import { Toaster } from 'cclkit4svelte';
 </script>
 
-<Toaster position="top-right" maxVisible={5} defaultDuration={3000} dismissible message="${message}" variant="${variant}" duration={0} />
+<Toaster position="top-right" maxVisible={5} dismissible message="${message}" variant="${variant}" duration={0} />
           `.trim()
         }
       }
@@ -189,24 +198,24 @@ function makeVariantStory(
 export const Success: Story = {
   ...makeVariantStory('success', 'Saved successfully'),
   parameters: {
-    controls: { include: ['position', 'maxVisible', 'defaultDuration', 'dismissible'] }
+    controls: { include: ['position', 'maxVisible', 'dismissible'] }
   }
 };
 export const Error: Story = {
   ...makeVariantStory('error', 'Something went wrong'),
   parameters: {
-    controls: { include: ['position', 'maxVisible', 'defaultDuration', 'dismissible'] }
+    controls: { include: ['position', 'maxVisible', 'dismissible'] }
   }
 };
 export const Warning: Story = {
   ...makeVariantStory('warning', 'Check your input'),
   parameters: {
-    controls: { include: ['position', 'maxVisible', 'defaultDuration', 'dismissible'] }
+    controls: { include: ['position', 'maxVisible', 'dismissible'] }
   }
 };
 export const Info: Story = {
   ...makeVariantStory('info', 'Here is some information'),
   parameters: {
-    controls: { include: ['position', 'maxVisible', 'defaultDuration', 'dismissible'] }
+    controls: { include: ['position', 'maxVisible', 'dismissible'] }
   }
 };

--- a/src/stories/ToasterPlayground.svelte
+++ b/src/stories/ToasterPlayground.svelte
@@ -23,5 +23,5 @@
       >Use controls to edit message/duration/variant, then click Show Toast.</span
     >
   {/if}
-  <Toaster {position} {maxVisible} {dismissible} />
+  <Toaster {position} {maxVisible} {dismissible} message="" duration={0} />
 </div>

--- a/src/stories/Tooltip.stories.ts
+++ b/src/stories/Tooltip.stories.ts
@@ -16,7 +16,6 @@ const meta = {
   argTypes: {
     text: {
       control: 'text',
-      type: { required: true },
       description: 'ツールチップとして表示されるテキスト'
     },
     position: {
@@ -93,7 +92,7 @@ export const AllColors: Story = {
   render: () => ({
     Component: AllColorsTooltipWrapper
   }),
-  args: {},
+  args: { text: 'Color sample' },
   parameters: {
     layout: 'fullscreen',
     docs: {


### PR DESCRIPTION
## 概要

Svelte 5への移行で顕在化したStorybookのProps型エラーを解消しました。

## 変更内容

- 色トークンやコンポーネント固有のunion型をStory factoryとwrapperへ適用
- AllColors Storyにも公開コンポーネントの必須Propsを設定
- FormGroupとAlertに型付きStory wrapperを追加
- AlertのdismissイベントとToasterの表示操作をDOMベースのinteraction testで検証
- Toaster Storyから存在しないdefaultDurationを削除し、durationへ統一
- Story固有Propsを持つHeaderWithDrawerなどのmetaをwrapperへ合わせて修正

## 確認結果

- pnpm check: src/stories配下のエラー0件
  - リポジトリ全体では27 errors / 11 warningsが残存（#111のsrc/lib、#113のsrc/routesの範囲）
- pnpm build-storybook: 成功
- test-storybook --maxWorkers 1: 172 passed / 2 failed
  - Pagination/MinimalControlsは既存の期待値不一致
  - Toasterは初回コンパイル時に毎回異なる1 Storyが15秒timeoutとなる一方、再実行時には直前の対象が成功することを確認

Closes #112