### PR TITLE
Svelte 5環境でデモルートの必須Props型エラーを解消する

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   // グローバルCSS変数を提供（開発デモ用）
   // ライブラリの副作用 import ではなく、CSS を直接読み込む
   import '$lib/const/variables.css';
@@ -18,21 +18,58 @@
   import TabPanel from '$lib/TabPanel.svelte';
   import Accordion from '$lib/Accordion.svelte';
   import AccordionItem from '$lib/AccordionItem.svelte';
+  import { CCLPastelColor, CCLVividColor } from '$lib/const/config';
+
+  const imageUrl = '/library_card.png';
+  const carouselImages = [
+    { src: imageUrl, alt: 'コンポーネントライブラリのカード' },
+    { src: imageUrl, alt: 'コンポーネントライブラリのカードの別表示' }
+  ];
+  const tableHeaders = ['Component', 'Status'];
+  const tableRows = [
+    ['Button', 'Ready'],
+    ['Card', 'Ready']
+  ];
 </script>
 
 <Header />
 <Button />
 <Footer />
-<Thumbnail />
-<Card />
-<Table />
-<Carousel />
-<CommonHeader />
+<Thumbnail
+  imageSize="160px"
+  borderColor={CCLVividColor.STRAWBERRY_PINK}
+  src={imageUrl}
+  altText="コンポーネントライブラリのサムネイル"
+/>
+<Card
+  borderColor={CCLVividColor.SODA_BLUE}
+  src={imageUrl}
+  altText="コンポーネントライブラリのカード"
+  title="Component Kit"
+  cardText="Svelte向けコンポーネントの開発デモです。"
+/>
+<Table tableColor={CCLVividColor.MELON_GREEN} dataHeader={tableHeaders} tableData={tableRows} />
+<Carousel src={carouselImages} csWidth="min(100%, 680px)" />
+<CommonHeader bgColor={CCLPastelColor.SUGAR_BLUE} logo="/favicon.png" logoHeight="40px" href="/" />
 <ChangeHistory />
-<ServiceCard />
-<BookCard />
+<ServiceCard
+  serviceName="Component Library"
+  description="Svelteアプリケーション向けのUIコンポーネント集です。"
+  {imageUrl}
+  altText="Component Library"
+/>
+<BookCard
+  title="Svelte Component Guide"
+  description="コンポーネントの利用例を紹介するデモカードです。"
+  coverImageUrl={imageUrl}
+  altText="Svelte Component Guide"
+/>
 <DatePicker />
-<Tabs />
-<TabPanel />
-<Accordion />
-<AccordionItem />
+<Tabs>
+  <TabPanel label="Overview">タブコンポーネントのデモです。</TabPanel>
+</Tabs>
+<Accordion>
+  <AccordionItem label="Details" isOpen={true}>
+    アコーディオンコンポーネントのデモです。
+  </AccordionItem>
+</Accordion>


### PR DESCRIPTION
## 概要

Svelte 5環境で検出されていたデモルートの必須Props型エラーを解消しました。

## 変更内容

- Thumbnail、Card、Table、Carousel、CommonHeaderへ必須Propsとデモデータを設定
- ServiceCard、BookCardへ表示確認可能なデモデータを設定
- TabPanelをTabs配下へ移動し、必須labelを設定
- AccordionItemをAccordion配下へ移動し、必須labelとデモ内容を設定
- 既存のstatic画像を利用し、外部依存なしで描画できるよう整理

## 確認結果

- pnpm check: src/routes/+page.svelteのエラー0件
  - 独立ブランチのため、リポジトリ全体では#111/#112範囲の72 errors / 11 warningsが残存
- pnpm build: 成功
- ブラウザ表示: Tabs、Accordion、ServiceCardのデモ描画を確認
- ブラウザconsole error: 0件

Closes #113