### PR TITLE
PrismaticWorkCardにdescriptionプロパティを追加

### DIFF
--- a/src/lib/PrismaticWorkCard.svelte
+++ b/src/lib/PrismaticWorkCard.svelte
@@ -9,6 +9,7 @@
 
   export type PrismaticWorkCardProps = {
     title?: string;
+    description?: string;
     href?: string;
     linkLabel?: string;
     imageUrl?: string;
@@ -22,6 +23,7 @@
   import type { ColorVar } from './const/config';
 
   export let title: string = 'CCL Component Kit';
+  export let description: string | undefined = undefined;
   export let href: string | undefined = undefined;
   export let linkLabel: string = 'VIEW PROJECT';
   export let imageUrl: string | undefined = undefined;
@@ -57,7 +59,13 @@
   </div>
 
   <div class="body">
-    <h3 class="title">{title}</h3>
+    <div class="copy">
+      <h3 class="title">{title}</h3>
+
+      {#if description}
+        <p class="description">{description}</p>
+      {/if}
+    </div>
 
     {#if href}
       <svelte:element
@@ -140,6 +148,14 @@
     min-width: 0;
   }
 
+  .copy {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
   .title {
     margin: 0;
     max-width: 100%;
@@ -147,6 +163,17 @@
     font-size: 26px;
     font-weight: 700;
     line-height: normal;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .description {
+    margin: 0;
+    max-width: 100%;
+    color: color-mix(in srgb, var(--palette-grape-900) 34%, var(--palette-wrap-800));
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.75;
     overflow-wrap: anywhere;
     word-break: normal;
   }

--- a/src/stories/AllColors/AllColorsPrismaticWorkCardWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticWorkCardWrapper.svelte
@@ -11,7 +11,12 @@
     <div class="work-card-grid">
       {#each vividColors as [name, tone] (name)}
         <div class="color-sample">
-          <PrismaticWorkCard title={`${name} の制作実績`} linkLabel="VIEW PROJECT" {tone} />
+          <PrismaticWorkCard
+            title={`${name}の制作実績`}
+            description="各toneで概要文の折り返しと余白を確認するためのサンプルです。"
+            linkLabel="VIEW PROJECT"
+            {tone}
+          />
         </div>
       {/each}
     </div>

--- a/src/stories/PrismaticWorkCard.stories.ts
+++ b/src/stories/PrismaticWorkCard.stories.ts
@@ -25,6 +25,9 @@ const meta = {
     title: {
       control: { type: 'text' }
     },
+    description: {
+      control: { type: 'text' }
+    },
     href: {
       control: { type: 'text' }
     },
@@ -63,11 +66,60 @@ export const Default: Story = {
       ).toBeInTheDocument();
     });
 
-    await step('CTAリンクが表示されていること', async () => {
+    await step('概要文なしでもCTAリンクが表示されていること', async () => {
       await expect(canvas.getByRole('link', { name: 'VIEW PROJECT' })).toHaveAttribute(
         'href',
         'https://example.com'
       );
+    });
+  }
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: 'CCL Component Kit',
+    description:
+      'Svelte向けのUIコンポーネントライブラリ。サイトやアプリで使う共通UIを、Prismatic Designの色彩でまとめます。',
+    href: 'https://www.npmjs.com/package/cclkit4svelte',
+    linkLabel: 'VIEW PROJECT',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('概要文がタイトルとリンクの間に表示されていること', async () => {
+      await expect(
+        canvas.getByText(
+          'Svelte向けのUIコンポーネントライブラリ。サイトやアプリで使う共通UIを、Prismatic Designの色彩でまとめます。'
+        )
+      ).toBeInTheDocument();
+    });
+
+    await step('概要文つきでもCTAリンクが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: 'VIEW PROJECT' })).toHaveAttribute(
+        'href',
+        'https://www.npmjs.com/package/cclkit4svelte'
+      );
+    });
+  }
+};
+
+export const LongDescription: Story = {
+  args: {
+    title: 'Selected Works Showcase',
+    description:
+      'Selected Worksで複数行の紹介文を表示する想定です。長めの説明や区切りのない英数字MixedContentForResponsiveLayoutVerificationが入っても、カード幅からはみ出さず読みやすく折り返されます。',
+    href: 'https://example.com',
+    linkLabel: 'VIEW PROJECT',
+    tone: CCLVividColor.MELON_GREEN
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('長い概要文が表示されていること', async () => {
+      await expect(
+        canvas.getByText(/Selected Worksで複数行の紹介文を表示する想定です/)
+      ).toBeInTheDocument();
     });
   }
 };
@@ -100,6 +152,7 @@ export const Japanese: Story = {
 export const WithImage: Story = {
   args: {
     title: '画像を差し込んだWorkCard',
+    description: '画像付きの制作実績として、プロジェクトの概要を短く添えます。',
     href: 'https://example.com',
     linkLabel: 'VIEW PROJECT',
     imageUrl: 'thumbnail.png',
@@ -113,8 +166,10 @@ export const WithImage: Story = {
       await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'WorkCardのサムネイル');
     });
 
-    await step('タイトルが表示されていること', async () => {
-      await expect(canvas.getByText('画像を差し込んだWorkCard')).toBeInTheDocument();
+    await step('画像つきでも概要文が表示されていること', async () => {
+      await expect(
+        canvas.getByText('画像付きの制作実績として、プロジェクトの概要を短く添えます。')
+      ).toBeInTheDocument();
     });
   }
 };
@@ -122,6 +177,7 @@ export const WithImage: Story = {
 export const WithoutLink: Story = {
   args: {
     title: 'リンクなしの制作実績',
+    description: '公開前のプロジェクトでも、概要文だけを先に表示できます。',
     linkLabel: 'COMING SOON',
     tone: CCLVividColor.PINEAPPLE_YELLOW
   },
@@ -158,7 +214,7 @@ export const MixedWithServiceCard: Story = {
     });
 
     await step('既存ServiceCardとの差分を確認できること', async () => {
-      await expect(canvas.getByText('Prismatic Design の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('Prismatic Designの制作実績')).toBeInTheDocument();
       await expect(canvas.getByText('既存サービスカード')).toBeInTheDocument();
     });
   }
@@ -189,12 +245,12 @@ export const AllColors: Story = {
     });
 
     await step('各tone名の制作実績が表示されていること', async () => {
-      await expect(canvas.getByText('STRAWBERRY_PINK の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('PINEAPPLE_YELLOW の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('SODA_BLUE の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('MELON_GREEN の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('GRAPE_PURPLE の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('WRAP_GREY の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('STRAWBERRY_PINKの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('PINEAPPLE_YELLOWの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('SODA_BLUEの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('MELON_GREENの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('GRAPE_PURPLEの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('WRAP_GREYの制作実績')).toBeInTheDocument();
     });
   }
 };

--- a/src/stories/PrismaticWorkCardMixedWrapper.svelte
+++ b/src/stories/PrismaticWorkCardMixedWrapper.svelte
@@ -8,7 +8,8 @@
   <section class="sample">
     <h2>PrismaticWorkCard</h2>
     <PrismaticWorkCard
-      title="Prismatic Design の制作実績"
+      title="Prismatic Designの制作実績"
+      description="選択した制作実績の目的や内容を短く伝える概要文を表示します。"
       href="https://example.com"
       linkLabel="VIEW PROJECT"
       imageUrl="thumbnail.png"


### PR DESCRIPTION
## 概要

Issue #125 に対応し、`PrismaticWorkCard` で制作実績の概要文を表示できるようにしました。

## 変更内容

- `PrismaticWorkCard` に任意の `description?: string` を追加
- `description` 指定時に、タイトルとリンクの間へ本文として表示
- 長い説明文や連続した英数字でもカード幅からはみ出しにくい折り返しスタイルを追加
- Storybook に概要文あり、長文、画像あり、リンクなし、All Colors の表示例と interaction test を追加
- WorkCard 比較用 wrapper と All Colors wrapper を概要文つきの表示に更新

## 確認結果

- `pnpm check`: 成功（0 errors / 11 warnings）
- `pnpm build-storybook`: 成功

既存の警告は `CommonHeader`、`DatePicker`、`Textarea` など今回の変更対象外のファイル由来です。

## 関連Issue

Closes #125
