### PR TITLE
Prismaticコンポーネントの表示バリエーションを追加

### DIFF
--- a/src/lib/PrismaticBookCard.svelte
+++ b/src/lib/PrismaticBookCard.svelte
@@ -196,5 +196,9 @@
       height: auto;
       aspect-ratio: 7 / 10;
     }
+
+    .size-large .cover-slot {
+      height: auto;
+    }
   }
 </style>

--- a/src/lib/PrismaticBookCard.svelte
+++ b/src/lib/PrismaticBookCard.svelte
@@ -7,11 +7,14 @@
     | '--grape-purple'
     | '--wrap-grey';
 
+  export type PrismaticBookCardSize = 'default' | 'large';
+
   export type PrismaticBookCardProps = {
     href?: string;
     linkLabel?: string;
     imageUrl?: string;
     imageAlt?: string;
+    size?: PrismaticBookCardSize;
     tone?: PrismaticBookCardTone;
   };
 </script>
@@ -24,6 +27,7 @@
   export let linkLabel: string = 'READ MORE';
   export let imageUrl: string | undefined = undefined;
   export let imageAlt: string = '';
+  export let size: PrismaticBookCardSize = 'default';
   export let tone: PrismaticBookCardTone = CCLVividColor.STRAWBERRY_PINK;
 
   const gradientEndColors: Record<string, ColorVar> = {
@@ -42,7 +46,7 @@
 </script>
 
 <article
-  class="prismatic-book-card"
+  class="prismatic-book-card size-{size}"
   style="--gradient-start: {gradientStart}; --gradient-end: {gradientEnd}; --accent-color: {accentColor};"
 >
   <div class="cover-slot" aria-label={imageUrl ? undefined : imageAlt || undefined}>
@@ -97,6 +101,13 @@
     letter-spacing: 0;
   }
 
+  .size-large {
+    gap: 24px;
+    width: min(100%, 370px);
+    height: 590px;
+    padding: 28px;
+  }
+
   .cover-slot {
     position: relative;
     display: flex;
@@ -107,6 +118,11 @@
     overflow: hidden;
     border-radius: 18px;
     background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+  }
+
+  .size-large .cover-slot {
+    height: 442px;
+    border-radius: 22px;
   }
 
   .cover-image,
@@ -140,6 +156,11 @@
     overflow-wrap: anywhere;
   }
 
+  .size-large .link,
+  .size-large .link-label {
+    font-size: 14px;
+  }
+
   .link-icon {
     display: block;
     flex: 0 0 16px;
@@ -165,6 +186,10 @@
     .prismatic-book-card {
       height: auto;
       min-height: 500px;
+    }
+
+    .size-large {
+      min-height: 590px;
     }
 
     .cover-slot {

--- a/src/lib/PrismaticBookCard.svelte
+++ b/src/lib/PrismaticBookCard.svelte
@@ -121,7 +121,8 @@
   }
 
   .size-large .cover-slot {
-    height: 442px;
+    height: auto;
+    aspect-ratio: 156 / 221;
     border-radius: 22px;
   }
 
@@ -195,10 +196,6 @@
     .cover-slot {
       height: auto;
       aspect-ratio: 7 / 10;
-    }
-
-    .size-large .cover-slot {
-      height: auto;
     }
   }
 </style>

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -12,6 +12,8 @@
     href: string;
   };
 
+  export type PrismaticSiteFooterDensity = 'default' | 'compact' | 'studio';
+
   export type PrismaticSiteFooterProps = {
     brand?: string;
     brandHref?: string;
@@ -21,6 +23,9 @@
     links?: PrismaticSiteFooterLink[];
     copyright?: string;
     ariaLabel?: string;
+    density?: PrismaticSiteFooterDensity;
+    studioGradientStart?: PrismaticSiteFooterTone;
+    studioGradientLast?: PrismaticSiteFooterTone;
     tone?: PrismaticSiteFooterTone;
   };
 </script>
@@ -43,6 +48,9 @@
   export let links: PrismaticSiteFooterLink[] = defaultLinks;
   export let copyright: string = `Copyright © ${year} CANDY CHUPS Lab. All Rights Reserved.`;
   export let ariaLabel: string = 'フッターナビゲーション';
+  export let density: PrismaticSiteFooterDensity = 'default';
+  export let studioGradientStart: PrismaticSiteFooterTone | undefined = undefined;
+  export let studioGradientLast: PrismaticSiteFooterTone | undefined = undefined;
   export let tone: PrismaticSiteFooterTone = CCLVividColor.STRAWBERRY_PINK;
 
   function toCssUrl(value: string): string {
@@ -58,11 +66,18 @@
   }
 
   $: accentColor = `var(${tone})`;
+  $: studioGradientStartColor = studioGradientStart
+    ? `var(${studioGradientStart})`
+    : 'var(--palette-grape-900)';
+  $: studioGradientLastColor = studioGradientLast ? `var(${studioGradientLast})` : accentColor;
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
   $: logoLabel = logoAlt?.trim() || brand;
 </script>
 
-<footer class="prismatic-site-footer" style="--accent-color: {accentColor};">
+<footer
+  class="prismatic-site-footer density-{density}"
+  style="--accent-color: {accentColor}; --studio-gradient-start: {studioGradientStartColor}; --studio-gradient-last: {studioGradientLastColor};"
+>
   <div class="footer-main">
     {#if brandHref}
       <a class="brand" href={brandHref}>
@@ -118,19 +133,31 @@
     min-height: 180px;
     box-sizing: border-box;
     padding: 40px 48px 32px;
-    border: 1.5px solid color-mix(in srgb, var(--accent-color) 52%, transparent);
+    border: 1.5px solid color-mix(in srgb, var(--accent-color) 64%, var(--palette-grape-900));
     border-radius: 34px;
     background: linear-gradient(
       112deg,
-      color-mix(in srgb, var(--accent-color) 78%, var(--color-surface-glass)) 0%,
-      color-mix(in srgb, var(--accent-color) 42%, var(--color-surface-glass)) 58%,
-      color-mix(in srgb, var(--accent-color) 18%, var(--color-surface-glass)) 100%
+      var(--studio-gradient-start) 0%,
+      color-mix(in srgb, var(--studio-gradient-start) 68%, var(--studio-gradient-last)) 54%,
+      var(--studio-gradient-last) 100%
     );
     box-shadow: 0 16px 20px color-mix(in srgb, var(--palette-grape-900) 18%, transparent);
-    color: var(--palette-grape-900);
+    color: var(--color-surface-glass);
     font-family: Inter, sans-serif;
     line-height: normal;
     letter-spacing: 0;
+  }
+
+  .density-compact {
+    gap: 20px;
+    min-height: 132px;
+    padding: 28px 36px 24px;
+  }
+
+  .density-studio {
+    gap: 40px;
+    min-height: 240px;
+    padding: 52px 56px 40px;
   }
 
   .footer-main {
@@ -154,7 +181,7 @@
     display: block;
     width: min(300px, 48vw);
     height: var(--logo-height);
-    background: var(--color-surface-glass);
+    background: currentColor;
     -webkit-mask: var(--logo-image) left center / contain no-repeat;
     mask: var(--logo-image) left center / contain no-repeat;
   }

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -39,7 +39,7 @@
   ];
 
   const year = new Date().getFullYear();
-  const lightLastTones: PrismaticSiteFooterTone[] = [
+  const lightTones: PrismaticSiteFooterTone[] = [
     CCLVividColor.PINEAPPLE_YELLOW,
     CCLVividColor.MELON_GREEN
   ];
@@ -73,9 +73,12 @@
   $: studioGradientStartColor = studioGradientStart
     ? `var(${studioGradientStart})`
     : 'var(--palette-grape-900)';
+  $: startTextColor = studioGradientStart && lightTones.includes(studioGradientStart)
+    ? 'var(--palette-grape-900)'
+    : 'var(--color-surface-glass)';
   $: lastTone = studioGradientLast ?? tone;
   $: studioGradientLastColor = `var(${lastTone})`;
-  $: footerTextColor = lightLastTones.includes(lastTone)
+  $: lastTextColor = lightTones.includes(lastTone)
     ? 'var(--palette-grape-900)'
     : 'var(--color-surface-glass)';
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
@@ -84,7 +87,7 @@
 
 <footer
   class="prismatic-site-footer density-{density}"
-  style="--accent-color: {accentColor}; --studio-gradient-start: {studioGradientStartColor}; --studio-gradient-last: {studioGradientLastColor}; --footer-text-color: {footerTextColor};"
+  style="--accent-color: {accentColor}; --studio-gradient-start: {studioGradientStartColor}; --studio-gradient-last: {studioGradientLastColor}; --footer-start-text-color: {startTextColor}; --footer-last-text-color: {lastTextColor};"
 >
   <div class="footer-main">
     {#if brandHref}
@@ -154,7 +157,7 @@
       var(--studio-gradient-last) 100%
     );
     box-shadow: 0 16px 20px color-mix(in srgb, var(--palette-grape-900) 18%, transparent);
-    color: var(--footer-text-color);
+    color: var(--footer-start-text-color);
     font-family: Inter, sans-serif;
     line-height: normal;
     letter-spacing: 0;
@@ -199,6 +202,7 @@
   }
 
   nav {
+    color: var(--footer-last-text-color);
     min-width: 0;
   }
 

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -271,6 +271,10 @@
       gap: 24px;
     }
 
+    nav {
+      color: var(--footer-start-text-color);
+    }
+
     ul {
       justify-content: flex-start;
     }

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -125,14 +125,18 @@
 
 <style>
   .prismatic-site-footer {
+    --footer-gap: 32px;
+    --footer-min-height: 180px;
+    --footer-padding: 40px 48px 32px;
+
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    gap: 32px;
+    gap: var(--footer-gap);
     width: min(100%, 1300px);
-    min-height: 180px;
+    min-height: var(--footer-min-height);
     box-sizing: border-box;
-    padding: 40px 48px 32px;
+    padding: var(--footer-padding);
     border: 1.5px solid color-mix(in srgb, var(--accent-color) 64%, var(--palette-grape-900));
     border-radius: 34px;
     background: linear-gradient(
@@ -149,15 +153,15 @@
   }
 
   .density-compact {
-    gap: 20px;
-    min-height: 132px;
-    padding: 28px 36px 24px;
+    --footer-gap: 20px;
+    --footer-min-height: 132px;
+    --footer-padding: 28px 36px 24px;
   }
 
   .density-studio {
-    gap: 40px;
-    min-height: 240px;
-    padding: 52px 56px 40px;
+    --footer-gap: 40px;
+    --footer-min-height: 240px;
+    --footer-padding: 52px 56px 40px;
   }
 
   .footer-main {
@@ -225,10 +229,23 @@
 
   @media (max-width: 640px) {
     .prismatic-site-footer {
-      gap: 28px;
-      min-height: 220px;
-      padding: 32px 28px 28px;
+      --footer-gap: 28px;
+      --footer-min-height: 220px;
+      --footer-padding: 32px 28px 28px;
+
       border-radius: 28px;
+    }
+
+    .density-compact {
+      --footer-gap: 20px;
+      --footer-min-height: 132px;
+      --footer-padding: 28px 28px 24px;
+    }
+
+    .density-studio {
+      --footer-gap: 40px;
+      --footer-min-height: 240px;
+      --footer-padding: 52px 28px 40px;
     }
 
     .footer-main {

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -39,10 +39,20 @@
   ];
 
   const year = new Date().getFullYear();
-  const lightTones: PrismaticSiteFooterTone[] = [
+  const darkTextTones: PrismaticSiteFooterTone[] = [
+    CCLVividColor.STRAWBERRY_PINK,
     CCLVividColor.PINEAPPLE_YELLOW,
+    CCLVividColor.SODA_BLUE,
     CCLVividColor.MELON_GREEN
   ];
+  const darkTextColor =
+    'color-mix(in srgb, var(--palette-grape-900) 70%, black)';
+
+  function getTextColor(tone: PrismaticSiteFooterTone | undefined): string {
+    return tone && darkTextTones.includes(tone)
+      ? darkTextColor
+      : 'var(--color-surface-glass)';
+  }
 
   export let brand: string = 'CANDY CHUPS Lab.';
   export let brandHref: string | undefined = undefined;
@@ -73,14 +83,10 @@
   $: studioGradientStartColor = studioGradientStart
     ? `var(${studioGradientStart})`
     : 'var(--palette-grape-900)';
-  $: startTextColor = studioGradientStart && lightTones.includes(studioGradientStart)
-    ? 'var(--palette-grape-900)'
-    : 'var(--color-surface-glass)';
+  $: startTextColor = getTextColor(studioGradientStart);
   $: lastTone = studioGradientLast ?? tone;
   $: studioGradientLastColor = `var(${lastTone})`;
-  $: lastTextColor = lightTones.includes(lastTone)
-    ? 'var(--palette-grape-900)'
-    : 'var(--color-surface-glass)';
+  $: lastTextColor = getTextColor(lastTone);
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
   $: logoLabel = logoAlt?.trim() || brand;
 </script>

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -39,6 +39,10 @@
   ];
 
   const year = new Date().getFullYear();
+  const lightLastTones: PrismaticSiteFooterTone[] = [
+    CCLVividColor.PINEAPPLE_YELLOW,
+    CCLVividColor.MELON_GREEN
+  ];
 
   export let brand: string = 'CANDY CHUPS Lab.';
   export let brandHref: string | undefined = undefined;
@@ -69,14 +73,18 @@
   $: studioGradientStartColor = studioGradientStart
     ? `var(${studioGradientStart})`
     : 'var(--palette-grape-900)';
-  $: studioGradientLastColor = studioGradientLast ? `var(${studioGradientLast})` : accentColor;
+  $: lastTone = studioGradientLast ?? tone;
+  $: studioGradientLastColor = `var(${lastTone})`;
+  $: footerTextColor = lightLastTones.includes(lastTone)
+    ? 'var(--palette-grape-900)'
+    : 'var(--color-surface-glass)';
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
   $: logoLabel = logoAlt?.trim() || brand;
 </script>
 
 <footer
   class="prismatic-site-footer density-{density}"
-  style="--accent-color: {accentColor}; --studio-gradient-start: {studioGradientStartColor}; --studio-gradient-last: {studioGradientLastColor};"
+  style="--accent-color: {accentColor}; --studio-gradient-start: {studioGradientStartColor}; --studio-gradient-last: {studioGradientLastColor}; --footer-text-color: {footerTextColor};"
 >
   <div class="footer-main">
     {#if brandHref}
@@ -146,7 +154,7 @@
       var(--studio-gradient-last) 100%
     );
     box-shadow: 0 16px 20px color-mix(in srgb, var(--palette-grape-900) 18%, transparent);
-    color: var(--color-surface-glass);
+    color: var(--footer-text-color);
     font-family: Inter, sans-serif;
     line-height: normal;
     letter-spacing: 0;

--- a/src/lib/PrismaticSiteHeader.svelte
+++ b/src/lib/PrismaticSiteHeader.svelte
@@ -13,12 +13,18 @@
     active?: boolean;
   };
 
+  export type PrismaticSiteHeaderLogoFit = 'contain' | 'cover';
+
   export type PrismaticSiteHeaderProps = {
     brand?: string;
     brandHref?: string;
     logoUrl?: string;
     logoAlt?: string;
     logoHeight?: string;
+    logoWidth?: string;
+    logoFit?: PrismaticSiteHeaderLogoFit;
+    padding?: string;
+    minHeight?: string;
     navigation?: PrismaticSiteHeaderItem[];
     ariaLabel?: string;
     tone?: PrismaticSiteHeaderTone;
@@ -41,6 +47,10 @@
   export let logoUrl: string | undefined = undefined;
   export let logoAlt: string | undefined = undefined;
   export let logoHeight: string = '40px';
+  export let logoWidth: string = 'min(260px, 40vw)';
+  export let logoFit: PrismaticSiteHeaderLogoFit = 'contain';
+  export let padding: string = '24px 35px';
+  export let minHeight: string = '104px';
   export let navigation: PrismaticSiteHeaderItem[] = defaultNavigation;
   export let ariaLabel: string = 'メインナビゲーション';
   export let tone: PrismaticSiteHeaderTone = CCLVividColor.STRAWBERRY_PINK;
@@ -64,7 +74,10 @@
   $: logoLabel = logoAlt?.trim() || brand;
 </script>
 
-<header class="prismatic-site-header" style="--accent-color: {accentColor};">
+<header
+  class="prismatic-site-header"
+  style="--accent-color: {accentColor}; --header-padding: {padding}; --header-min-height: {minHeight};"
+>
   {#if brandHref}
     <svelte:element this={brandLinkElement} class="brand" href={brandHref}>
       {#if logoUrl}
@@ -73,10 +86,10 @@
           role="img"
           aria-label={logoLabel}
           data-logo-url={logoUrl}
-          style="--logo-height: {logoHeight}; --logo-image: {logoImage};"
+          style="--logo-height: {logoHeight}; --logo-width: {logoWidth}; --logo-fit: {logoFit}; --logo-image: {logoImage};"
         ></span>
       {:else}
-        {brand}
+        <slot name="logo">{brand}</slot>
       {/if}
     </svelte:element>
   {:else}
@@ -87,10 +100,10 @@
           role="img"
           aria-label={logoLabel}
           data-logo-url={logoUrl}
-          style="--logo-height: {logoHeight}; --logo-image: {logoImage};"
+          style="--logo-height: {logoHeight}; --logo-width: {logoWidth}; --logo-fit: {logoFit}; --logo-image: {logoImage};"
         ></span>
       {:else}
-        {brand}
+        <slot name="logo">{brand}</slot>
       {/if}
     </span>
   {/if}
@@ -119,9 +132,9 @@
     justify-content: space-between;
     gap: 32px;
     width: min(100%, 1300px);
-    min-height: 104px;
+    min-height: var(--header-min-height);
     box-sizing: border-box;
-    padding: 24px 35px;
+    padding: var(--header-padding);
     border: 1.5px solid color-mix(in srgb, var(--accent-color) 42%, transparent);
     border-radius: 34px;
     background: color-mix(in srgb, var(--color-surface-glass) 78%, transparent);
@@ -144,12 +157,12 @@
 
   .brand-logo {
     display: block;
-    width: min(260px, 40vw);
-    max-width: min(260px, 40vw);
+    width: var(--logo-width);
+    max-width: min(100%, 48vw);
     height: var(--logo-height);
     background: var(--accent-color);
-    -webkit-mask: var(--logo-image) left center / contain no-repeat;
-    mask: var(--logo-image) left center / contain no-repeat;
+    -webkit-mask: var(--logo-image) left center / var(--logo-fit) no-repeat;
+    mask: var(--logo-image) left center / var(--logo-fit) no-repeat;
   }
 
   nav {

--- a/src/lib/PrismaticSiteHeader.svelte
+++ b/src/lib/PrismaticSiteHeader.svelte
@@ -49,8 +49,8 @@
   export let logoHeight: string = '40px';
   export let logoWidth: string = 'min(260px, 40vw)';
   export let logoFit: PrismaticSiteHeaderLogoFit = 'contain';
-  export let padding: string = '24px 35px';
-  export let minHeight: string = '104px';
+  export let padding: string | undefined = undefined;
+  export let minHeight: string | undefined = undefined;
   export let navigation: PrismaticSiteHeaderItem[] = defaultNavigation;
   export let ariaLabel: string = 'メインナビゲーション';
   export let tone: PrismaticSiteHeaderTone = CCLVividColor.STRAWBERRY_PINK;
@@ -70,13 +70,17 @@
   }
 
   $: accentColor = `var(${tone})`;
+  $: headerPadding = padding ?? '24px 35px';
+  $: headerMobilePadding = padding ?? '22px 28px';
+  $: headerSmallPadding = padding ?? '20px 22px';
+  $: headerMinHeight = minHeight ?? '104px';
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
   $: logoLabel = logoAlt?.trim() || brand;
 </script>
 
 <header
   class="prismatic-site-header"
-  style="--accent-color: {accentColor}; --header-padding: {padding}; --header-min-height: {minHeight};"
+  style="--accent-color: {accentColor}; --header-padding: {headerPadding}; --header-mobile-padding: {headerMobilePadding}; --header-small-padding: {headerSmallPadding}; --header-min-height: {headerMinHeight};"
 >
   {#if brandHref}
     <svelte:element this={brandLinkElement} class="brand" href={brandHref}>
@@ -222,8 +226,8 @@
       flex-direction: column;
       align-items: flex-start;
       gap: 12px;
-      min-height: 104px;
-      padding: 22px 28px;
+      min-height: var(--header-min-height);
+      padding: var(--header-mobile-padding);
     }
 
     nav {
@@ -241,7 +245,7 @@
 
   @media (max-width: 480px) {
     .prismatic-site-header {
-      padding: 20px 22px;
+      padding: var(--header-small-padding);
       border-radius: 28px;
     }
 

--- a/src/lib/PrismaticStoryCard.svelte
+++ b/src/lib/PrismaticStoryCard.svelte
@@ -13,6 +13,7 @@
     label?: string;
     href?: string;
     linkLabel?: string;
+    showLink?: boolean;
     imageUrl?: string;
     imageAlt?: string;
     squareImage?: boolean;
@@ -34,6 +35,7 @@
   export let label: string | undefined = undefined;
   export let href: string | undefined = undefined;
   export let linkLabel: string = 'Read more';
+  export let showLink: boolean = true;
   export let imageUrl: string | undefined = undefined;
   export let imageAlt: string = '';
   export let squareImage: boolean = false;
@@ -101,7 +103,7 @@
 
     <h3 class="title">{title}</h3>
 
-    {#if href}
+    {#if href && showLink}
       <svelte:element
         this={linkElement}
         class="link"

--- a/src/stories/AllColors/AllColorsPrismaticSiteFooterWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticSiteFooterWrapper.svelte
@@ -11,6 +11,7 @@
       <h2>{name}</h2>
       <PrismaticSiteFooter
         {tone}
+        density="studio"
         brandHref="/"
         logoUrl="candy-chups-lab.svg"
         logoAlt="CANDY CHUPS Lab."

--- a/src/stories/PrismaticBookCard.stories.ts
+++ b/src/stories/PrismaticBookCard.stories.ts
@@ -98,6 +98,14 @@ export const Large: Story = {
         'https://example.com'
       );
     });
+
+    await step('幅が変わってもlarge表紙の比率が維持されること', async () => {
+      const cover = canvasElement.querySelector('.cover-slot');
+
+      await expect(cover).not.toBeNull();
+      const { width, height } = (cover as HTMLElement).getBoundingClientRect();
+      await expect(width / height).toBeCloseTo(156 / 221, 2);
+    });
   }
 };
 

--- a/src/stories/PrismaticBookCard.stories.ts
+++ b/src/stories/PrismaticBookCard.stories.ts
@@ -26,6 +26,7 @@ const meta = {
     linkLabel: { control: { type: 'text' } },
     imageUrl: { control: { type: 'text' } },
     imageAlt: { control: { type: 'text' } },
+    size: { control: { type: 'select' }, options: ['default', 'large'] },
     tone: {
       control: { type: 'select' },
       options: toneOptions
@@ -67,6 +68,35 @@ export const WithImage: Story = {
 
     await step('表紙画像にalt属性が設定されていること', async () => {
       await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'PrismaticBookCardの書影');
+    });
+  }
+};
+
+export const Large: Story = {
+  args: {
+    href: 'https://example.com',
+    linkLabel: 'READ MORE',
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'largeサイズのPrismaticBookCard表紙',
+    size: 'large',
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('largeサイズをStorybookで選択できること', async () => {
+      await expect(args.size).toBe('large');
+    });
+
+    await step('largeサイズでもリンクと画像が表示されること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute(
+        'alt',
+        'largeサイズのPrismaticBookCard表紙'
+      );
+      await expect(canvas.getByRole('link', { name: 'READ MORE' })).toHaveAttribute(
+        'href',
+        'https://example.com'
+      );
     });
   }
 };

--- a/src/stories/PrismaticSiteFooter.stories.ts
+++ b/src/stories/PrismaticSiteFooter.stories.ts
@@ -23,6 +23,9 @@ const meta = {
     links: { control: { type: 'object' } },
     copyright: { control: { type: 'text' } },
     ariaLabel: { control: { type: 'text' } },
+    density: { control: { type: 'select' }, options: ['default', 'compact', 'studio'] },
+    studioGradientStart: { control: { type: 'select' }, options: toneOptions },
+    studioGradientLast: { control: { type: 'select' }, options: toneOptions },
     tone: {
       control: { type: 'select' },
       options: toneOptions
@@ -97,6 +100,93 @@ export const CustomContent: Story = {
   }
 };
 
+export const StudioDensity: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    brandHref: '/',
+    links: [
+      { label: 'WORKS', href: '#works' },
+      { label: 'BOOKS', href: '#books' },
+      { label: 'CONTACT', href: '#contact' }
+    ],
+    copyright: '© 2026 CANDY CHUPS Lab.',
+    density: 'studio',
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('studio密度を指定できること', async () => {
+      await expect(args.density).toBe('studio');
+    });
+
+    await step('studioデザインでもリンクとコピーライトが表示されること', async () => {
+      await expect(canvas.getByRole('link', { name: 'WORKS' })).toHaveAttribute(
+        'href',
+        '#works'
+      );
+      await expect(canvas.getByText('© 2026 CANDY CHUPS Lab.')).toBeInTheDocument();
+    });
+  }
+};
+
+export const StudioCustomGradient: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    brandHref: '/',
+    links: [
+      { label: 'WORKS', href: '#works' },
+      { label: 'BOOKS', href: '#books' },
+      { label: 'CONTACT', href: '#contact' }
+    ],
+    copyright: '© 2026 CANDY CHUPS Lab.',
+    density: 'studio',
+    studioGradientStart: CCLVividColor.GRAPE_PURPLE,
+    studioGradientLast: CCLVividColor.PINEAPPLE_YELLOW,
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('studioグラデーション色を指定できること', async () => {
+      await expect(args.studioGradientStart).toBe(CCLVividColor.GRAPE_PURPLE);
+      await expect(args.studioGradientLast).toBe(CCLVividColor.PINEAPPLE_YELLOW);
+    });
+
+    await step('カスタムグラデーションでも主要情報が表示されること', async () => {
+      await expect(canvas.getByRole('link', { name: 'WORKS' })).toHaveAttribute(
+        'href',
+        '#works'
+      );
+      await expect(canvas.getByText('© 2026 CANDY CHUPS Lab.')).toBeInTheDocument();
+    });
+  }
+};
+
+export const CompactDensity: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    links: [{ label: 'CONTACT', href: '#contact' }],
+    density: 'compact',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('compact密度を指定できること', async () => {
+      await expect(args.density).toBe('compact');
+    });
+
+    await step('compact密度でも主要情報が表示されること', async () => {
+      await expect(canvas.getByText('CANDY CHUPS Lab.')).toBeInTheDocument();
+      await expect(canvas.getByRole('link', { name: 'CONTACT' })).toHaveAttribute(
+        'href',
+        '#contact'
+      );
+    });
+  }
+};
+
 export const MixedWithFooter: Story = {
   render: () => ({ Component: PrismaticSiteFooterMixedWrapper }),
   args: {},
@@ -118,7 +208,7 @@ export const AllColors: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step('すべてのtone名が表示されていること', async () => {
+    await step('studioのカラーバリエーションが表示されていること', async () => {
       for (const name of Object.keys(CCLVividColor)) {
         await expect(canvas.getByRole('heading', { name })).toBeInTheDocument();
       }

--- a/src/stories/PrismaticSiteFooter.stories.ts
+++ b/src/stories/PrismaticSiteFooter.stories.ts
@@ -187,6 +187,31 @@ export const CompactDensity: Story = {
   }
 };
 
+export const MobileCompactDensity: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    links: [{ label: 'CONTACT', href: '#contact' }],
+    density: 'compact',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('モバイル向けcompact表示でも主要情報が表示されること', async () => {
+      await expect(canvas.getByText('CANDY CHUPS Lab.')).toBeInTheDocument();
+      await expect(canvas.getByRole('link', { name: 'CONTACT' })).toHaveAttribute(
+        'href',
+        '#contact'
+      );
+    });
+  }
+};
+
 export const MixedWithFooter: Story = {
   render: () => ({ Component: PrismaticSiteFooterMixedWrapper }),
   args: {},

--- a/src/stories/PrismaticSiteHeader.stories.ts
+++ b/src/stories/PrismaticSiteHeader.stories.ts
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test';
 import PrismaticSiteHeader from '$lib/PrismaticSiteHeader.svelte';
 import { CCLVividColor } from '$lib/const/config';
 import AllColorsPrismaticSiteHeaderWrapper from './AllColors/AllColorsPrismaticSiteHeaderWrapper.svelte';
+import PrismaticSiteHeaderLogoSlotWrapper from './PrismaticSiteHeaderLogoSlotWrapper.svelte';
 import PrismaticSiteHeaderMixedWrapper from './PrismaticSiteHeaderMixedWrapper.svelte';
 
 const toneOptions = [
@@ -27,6 +28,10 @@ const meta = {
     logoUrl: { control: { type: 'text' } },
     logoAlt: { control: { type: 'text' } },
     logoHeight: { control: { type: 'text' } },
+    logoWidth: { control: { type: 'text' } },
+    logoFit: { control: { type: 'select' }, options: ['contain', 'cover'] },
+    padding: { control: { type: 'text' } },
+    minHeight: { control: { type: 'text' } },
     navigation: { control: { type: 'object' } },
     ariaLabel: { control: { type: 'text' } },
     tone: {
@@ -86,6 +91,48 @@ export const WithLogo: Story = {
         'href',
         '/'
       );
+    });
+  }
+};
+
+export const CompactLogoLayout: Story = {
+  args: {
+    brandHref: '/',
+    logoUrl: 'candy-chups-lab.svg',
+    logoAlt: 'CANDY CHUPS Lab.',
+    logoHeight: '48px',
+    logoWidth: '180px',
+    logoFit: 'contain',
+    padding: '18px 28px',
+    minHeight: '84px',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('ロゴ幅とヘッダー密度を指定できること', async () => {
+      const logo = canvas.getByRole('img', { name: 'CANDY CHUPS Lab.' });
+      await expect(logo.style.getPropertyValue('--logo-width')).toBe('180px');
+      await expect(logo.style.getPropertyValue('--logo-fit')).toBe('contain');
+    });
+  }
+};
+
+export const WithLogoSlot: Story = {
+  render: () => ({ Component: PrismaticSiteHeaderLogoSlotWrapper }),
+  args: {},
+  parameters: {
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('ロゴslotの内容がブランドリンクとして表示されること', async () => {
+      await expect(canvas.getByRole('link', { name: 'CCL Studio' })).toHaveAttribute('href', '/');
     });
   }
 };

--- a/src/stories/PrismaticSiteHeaderLogoSlotWrapper.svelte
+++ b/src/stories/PrismaticSiteHeaderLogoSlotWrapper.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import PrismaticSiteHeader from '../lib/PrismaticSiteHeader.svelte';
+  import { CCLVividColor } from '../lib/const/config';
+</script>
+
+<div class="canvas">
+  <PrismaticSiteHeader
+    brandHref="/"
+    padding="18px 28px"
+    minHeight="84px"
+    tone={CCLVividColor.SODA_BLUE}
+  >
+    <span slot="logo" class="custom-logo">CCL Studio</span>
+  </PrismaticSiteHeader>
+</div>
+
+<style>
+  .canvas {
+    padding: 24px;
+  }
+
+  .custom-logo {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    color: inherit;
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/src/stories/PrismaticStoryCard.stories.ts
+++ b/src/stories/PrismaticStoryCard.stories.ts
@@ -35,6 +35,9 @@ const meta = {
     linkLabel: {
       control: { type: 'text' }
     },
+    showLink: {
+      control: { type: 'boolean' }
+    },
     imageUrl: {
       control: { type: 'text' }
     },
@@ -140,6 +143,37 @@ export const WithImage: Story = {
 
     await step('タイトルが表示されていること', async () => {
       await expect(canvas.getByText('画像を差し込んだStoryCard')).toBeInTheDocument();
+    });
+  }
+};
+
+export const WithoutInlineLink: Story = {
+  args: {
+    title: 'Selected Story Feature',
+    label: 'FEATURE',
+    href: 'https://example.com',
+    linkLabel: 'READ MORE',
+    showLink: false,
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'リンク非表示のStoryCardサムネイル',
+    size: 'featured',
+    tone: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('タイトルと画像が中心の表示になること', async () => {
+      await expect(
+        canvas.getByRole('heading', { name: 'Selected Story Feature', level: 3 })
+      ).toBeInTheDocument();
+      await expect(canvas.getByRole('img')).toHaveAttribute(
+        'alt',
+        'リンク非表示のStoryCardサムネイル'
+      );
+    });
+
+    await step('showLinkがfalseのときREAD MOREリンクが表示されないこと', async () => {
+      await expect(canvas.queryByRole('link', { name: 'READ MORE' })).not.toBeInTheDocument();
     });
   }
 };


### PR DESCRIPTION
﻿## 概要
- PrismaticSiteHeader にロゴ幅、fit、余白、最小高さ、ロゴslotの調整口を追加しました。
- PrismaticStoryCard にリンク表示を抑制できる `showLink` を追加しました。
- PrismaticBookCard に `size="large"` を追加し、Official Site向けの大きい書籍カード表示に対応しました。
- PrismaticSiteFooter をStudioデザインに一本化し、Vividカラーパレット由来のグラデーション指定とdensityを追加しました。
- 各変更に対応するStorybook storyとAllColors表示を更新しました。

## 関連Issue
Closes #126

## 確認
- `pnpm check`
- `pnpm build-storybook`
