### PR TITLE
Paginationのページ更新後に表示項目を再計算する

### DIFF
--- a/src/lib/Pagination.svelte
+++ b/src/lib/Pagination.svelte
@@ -17,21 +17,26 @@
   const dispatch = createEventDispatcher<{ change: { page: number } }>();
 
   // normalize and clamp helpers
-  function getPageCount(): number {
-    const count = pageCount ?? (total && perPage ? Math.ceil(total / perPage) : 1);
+  function getPageCount(
+    pageCountValue: number | undefined,
+    totalValue: number | undefined,
+    perPageValue: number
+  ): number {
+    const count =
+      pageCountValue ?? (totalValue && perPageValue ? Math.ceil(totalValue / perPageValue) : 1);
     return Math.max(1, count || 1);
   }
 
-  function clampPage(p: number): number {
-    const max = getPageCount();
-    return Math.min(Math.max(1, Math.trunc(p || 1)), max);
+  function clampPage(p: number, totalPages: number): number {
+    return Math.min(Math.max(1, Math.trunc(p || 1)), totalPages);
   }
 
-  $: page = clampPage(page);
+  $: totalPages = getPageCount(pageCount, total, perPage);
+  $: page = clampPage(page, totalPages);
 
   function goTo(p: number) {
     if (disabled) return;
-    const next = clampPage(p);
+    const next = clampPage(p, totalPages);
     if (next !== page) {
       page = next;
       dispatch('change', { page });
@@ -44,37 +49,50 @@
     return Array.from({ length: end - start + 1 }, (_, i) => start + i);
   }
 
-  function usePagination(): Item[] {
-    const totalPages = getPageCount();
-
+  function usePagination(
+    currentPage: number,
+    totalPages: number,
+    currentBoundaryCount: number,
+    currentSiblingCount: number
+  ): Item[] {
     // total pages small enough to show all
-    const totalNumbers = boundaryCount * 2 + siblingCount * 2 + 3; // first + last + current
+    const totalNumbers = currentBoundaryCount * 2 + currentSiblingCount * 2 + 3; // first + last + current
     const totalBlocks = totalNumbers + 2; // with two ellipses
 
     if (totalPages <= totalBlocks) {
       return range(1, totalPages);
     }
 
-    const startPages = range(1, Math.min(boundaryCount, totalPages));
+    const startPages = range(1, Math.min(currentBoundaryCount, totalPages));
     const endPages = range(
-      Math.max(totalPages - boundaryCount + 1, boundaryCount + 1),
+      Math.max(totalPages - currentBoundaryCount + 1, currentBoundaryCount + 1),
       totalPages
     );
 
     const siblingsStart = Math.max(
-      Math.min(page - siblingCount, totalPages - boundaryCount - siblingCount * 2 - 1),
-      boundaryCount + 2
+      Math.min(
+        currentPage - currentSiblingCount,
+        totalPages - currentBoundaryCount - currentSiblingCount * 2 - 1
+      ),
+      currentBoundaryCount + 2
     );
     const siblingsEnd = Math.min(
-      Math.max(page + siblingCount, boundaryCount + siblingCount * 2 + 2),
+      Math.max(
+        currentPage + currentSiblingCount,
+        currentBoundaryCount + currentSiblingCount * 2 + 2
+      ),
       endPages[0] - 2
     );
 
     const items: Item[] = [
       ...startPages,
-      siblingsStart > boundaryCount + 2 ? 'ellipsis' : (boundaryCount + 1) as unknown as Item,
+      siblingsStart > currentBoundaryCount + 2
+        ? 'ellipsis'
+        : ((currentBoundaryCount + 1) as unknown as Item),
       ...range(siblingsStart, siblingsEnd),
-      siblingsEnd < totalPages - boundaryCount - 1 ? 'ellipsis' : (totalPages - boundaryCount) as unknown as Item,
+      siblingsEnd < totalPages - currentBoundaryCount - 1
+        ? 'ellipsis'
+        : ((totalPages - currentBoundaryCount) as unknown as Item),
       ...endPages
     ];
 
@@ -92,11 +110,11 @@
     return normalized;
   }
 
-  $: items = usePagination();
+  $: items = usePagination(page, totalPages, boundaryCount, siblingCount);
 
   onMount(() => {
     // Ensure initial page is clamped and consumers can react if needed
-    const normalized = clampPage(page);
+    const normalized = clampPage(page, totalPages);
     if (normalized !== page) {
       page = normalized;
       dispatch('change', { page });
@@ -152,7 +170,7 @@
         <button
           class="ccl-pagination__control"
           on:click={() => goTo(page + 1)}
-          disabled={disabled || page === getPageCount()}
+          disabled={disabled || page === totalPages}
           aria-label="go to next page"
           type="button"
         >›</button>
@@ -162,8 +180,8 @@
       <li>
         <button
           class="ccl-pagination__control"
-          on:click={() => goTo(getPageCount())}
-          disabled={disabled || page === getPageCount()}
+          on:click={() => goTo(totalPages)}
+          disabled={disabled || page === totalPages}
           aria-label="go to last page"
           type="button"
         >»</button>

--- a/src/stories/Pagination.stories.ts
+++ b/src/stories/Pagination.stories.ts
@@ -61,13 +61,13 @@ export const Default: Story = {
     await step('次へをクリックすると、アクティブページが 2 になること', async () => {
       const next = await canvas.getByRole('button', { name: /go to next page/i });
       await userEvent.click(next);
-      const page2 = await canvas.getByRole('button', { name: /go to page 2/i });
+      const page2 = await canvas.findByRole('button', { name: /go to page 2/i });
       await expect(page2).toHaveAttribute('aria-current', 'page');
     });
     await step('最後へをクリックすると、アクティブページが 最終 になること', async () => {
       const last = await canvas.getByRole('button', { name: /go to last page/i });
       await userEvent.click(last);
-      const lastPage = await canvas.getByRole('button', { name: /go to page 12/i });
+      const lastPage = await canvas.findByRole('button', { name: /go to page 12/i });
       await expect(lastPage).toHaveAttribute('aria-current', 'page');
     });
   }
@@ -89,13 +89,13 @@ export const ManyPages: Story = {
     await step('前へをクリックすると、アクティブページが 9 になること', async () => {
       const prev = await canvas.getByRole('button', { name: /go to previous page/i });
       await userEvent.click(prev);
-      const page9 = await canvas.getByRole('button', { name: /go to page 9/i });
+      const page9 = await canvas.findByRole('button', { name: /go to page 9/i });
       await expect(page9).toHaveAttribute('aria-current', 'page');
     });
     await step('最後へをクリックすると、アクティブページが 最終 になること', async () => {
       const last = await canvas.getByRole('button', { name: /go to last page/i });
       await userEvent.click(last);
-      const page50 = await canvas.getByRole('button', { name: /go to page 50/i });
+      const page50 = await canvas.findByRole('button', { name: /go to page 50/i });
       await expect(page50).toHaveAttribute('aria-current', 'page');
     });
   }
@@ -117,13 +117,13 @@ export const MinimalControls: Story = {
     await step('次へをクリックすると、アクティブページが 4 になること', async () => {
       const next = await canvas.getByRole('button', { name: /go to next page/i });
       await userEvent.click(next);
-      const page4 = await canvas.getByRole('button', { name: /go to page 4/i });
+      const page4 = await canvas.findByRole('button', { name: /go to page 4/i });
       await expect(page4).toHaveAttribute('aria-current', 'page');
     });
     await step('前へをクリックすると、アクティブページが 3 に戻ること', async () => {
       const prev = await canvas.getByRole('button', { name: /go to previous page/i });
       await userEvent.click(prev);
-      const page3 = await canvas.getByRole('button', { name: /go to page 3/i });
+      const page3 = await canvas.findByRole('button', { name: /go to page 3/i });
       await expect(page3).toHaveAttribute('aria-current', 'page');
     });
   }


### PR DESCRIPTION
## 概要

`siblingCount={0}` のPaginationで、ページ移動後に表示ページ一覧が更新されず、MinimalControlsのStorybookテストが失敗する問題を修正しました。

## 変更内容

- ページ数と表示ページ一覧の計算に必要な値をリアクティブ依存として明示
- 現在ページの変更時に表示ページ一覧を再計算
- Storybookの操作後アサーションでSvelteの描画完了を待機

## 確認結果

- `pnpm check`（0 errors、既存の11 warnings）
- `pnpm build-storybook`
- `pnpm exec test-storybook --url http://127.0.0.1:6007 --maxWorkers 1`
  - PaginationのDefault / ManyPages / MinimalControlsはすべて成功
  - 全体は184件中183件成功。今回と無関係な既存のToaster Defaultのみ失敗

## 関連Issue

Closes #129