### PR TITLE
READMEのnpm公開バッジの参照条件を修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ccl-component-kit4svelte
 
 [![Release Storybook to GitHubPages](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml)
-[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
+[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
 
 ![library_card](static/library_card.png)
 

--- a/src/stories/README.mdx
+++ b/src/stories/README.mdx
@@ -5,7 +5,7 @@ import { Meta } from '@storybook/blocks';
 # ccl-component-kit4svelte
 
 [![Release Storybook to GitHubPages](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml)
-[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
+[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
 
 ![library_card](library_card.png)
 


### PR DESCRIPTION
## 概要

READMEとStorybook内READMEの `Publish Package to npmjs` バッジが、release起点のworkflowと一致する状態を表示するよう修正しました。

## 変更内容

- `README.md` の `publish-package.yaml` バッジURLから `?branch=main` を削除
- `src/stories/README.mdx` の同バッジURLも同様に修正
- release publishedで動くworkflow全体の直近状態を参照するよう統一

## 確認結果

- `pnpm check`: 成功（0 errors、既存の11 warnings）
- `pnpm build-storybook`: 成功
- 修正後のバッジURLがHTTP 200で `image/svg+xml` を返すことを確認

## 関連Issue

Closes #130