### PR TITLE
Release 4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ccl-component-kit4svelte
 
 [![Release Storybook to GitHubPages](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml)
-[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
+[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
 
 ![library_card](static/library_card.png)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [4.0.1](https://github.com/reiji1020/ccl-component-kit4svelte/compare/4.0.0...4.0.1) (2026/07/19)
+
+### Features
+
+- Added optional descriptions to PrismaticWorkCard with long-text wrapping and expanded Storybook coverage. (#125, #127)
+- Added configurable Prismatic component variants for headers, story and book cards, and Studio footers. (#126, #128)
+
+### Bug Fixes
+
+- Recomputed Pagination items after page changes, including minimal controls with `siblingCount={0}`. (#129, #131)
+
+### Maintenance
+
+- Aligned the npm publish workflow badges in the repository and Storybook READMEs with release-triggered runs. (#130, #132)
+
 ## [4.0.0](https://github.com/reiji1020/ccl-component-kit4svelte/compare/3.1.0...4.0.0) (2026/07/15)
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cclkit4svelte",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "reiji1020 <sk@reiji1020.info>",
   "license": "MIT",
   "type": "module",

--- a/src/lib/Pagination.svelte
+++ b/src/lib/Pagination.svelte
@@ -17,21 +17,26 @@
   const dispatch = createEventDispatcher<{ change: { page: number } }>();
 
   // normalize and clamp helpers
-  function getPageCount(): number {
-    const count = pageCount ?? (total && perPage ? Math.ceil(total / perPage) : 1);
+  function getPageCount(
+    pageCountValue: number | undefined,
+    totalValue: number | undefined,
+    perPageValue: number
+  ): number {
+    const count =
+      pageCountValue ?? (totalValue && perPageValue ? Math.ceil(totalValue / perPageValue) : 1);
     return Math.max(1, count || 1);
   }
 
-  function clampPage(p: number): number {
-    const max = getPageCount();
-    return Math.min(Math.max(1, Math.trunc(p || 1)), max);
+  function clampPage(p: number, totalPages: number): number {
+    return Math.min(Math.max(1, Math.trunc(p || 1)), totalPages);
   }
 
-  $: page = clampPage(page);
+  $: totalPages = getPageCount(pageCount, total, perPage);
+  $: page = clampPage(page, totalPages);
 
   function goTo(p: number) {
     if (disabled) return;
-    const next = clampPage(p);
+    const next = clampPage(p, totalPages);
     if (next !== page) {
       page = next;
       dispatch('change', { page });
@@ -44,37 +49,50 @@
     return Array.from({ length: end - start + 1 }, (_, i) => start + i);
   }
 
-  function usePagination(): Item[] {
-    const totalPages = getPageCount();
-
+  function usePagination(
+    currentPage: number,
+    totalPages: number,
+    currentBoundaryCount: number,
+    currentSiblingCount: number
+  ): Item[] {
     // total pages small enough to show all
-    const totalNumbers = boundaryCount * 2 + siblingCount * 2 + 3; // first + last + current
+    const totalNumbers = currentBoundaryCount * 2 + currentSiblingCount * 2 + 3; // first + last + current
     const totalBlocks = totalNumbers + 2; // with two ellipses
 
     if (totalPages <= totalBlocks) {
       return range(1, totalPages);
     }
 
-    const startPages = range(1, Math.min(boundaryCount, totalPages));
+    const startPages = range(1, Math.min(currentBoundaryCount, totalPages));
     const endPages = range(
-      Math.max(totalPages - boundaryCount + 1, boundaryCount + 1),
+      Math.max(totalPages - currentBoundaryCount + 1, currentBoundaryCount + 1),
       totalPages
     );
 
     const siblingsStart = Math.max(
-      Math.min(page - siblingCount, totalPages - boundaryCount - siblingCount * 2 - 1),
-      boundaryCount + 2
+      Math.min(
+        currentPage - currentSiblingCount,
+        totalPages - currentBoundaryCount - currentSiblingCount * 2 - 1
+      ),
+      currentBoundaryCount + 2
     );
     const siblingsEnd = Math.min(
-      Math.max(page + siblingCount, boundaryCount + siblingCount * 2 + 2),
+      Math.max(
+        currentPage + currentSiblingCount,
+        currentBoundaryCount + currentSiblingCount * 2 + 2
+      ),
       endPages[0] - 2
     );
 
     const items: Item[] = [
       ...startPages,
-      siblingsStart > boundaryCount + 2 ? 'ellipsis' : (boundaryCount + 1) as unknown as Item,
+      siblingsStart > currentBoundaryCount + 2
+        ? 'ellipsis'
+        : ((currentBoundaryCount + 1) as unknown as Item),
       ...range(siblingsStart, siblingsEnd),
-      siblingsEnd < totalPages - boundaryCount - 1 ? 'ellipsis' : (totalPages - boundaryCount) as unknown as Item,
+      siblingsEnd < totalPages - currentBoundaryCount - 1
+        ? 'ellipsis'
+        : ((totalPages - currentBoundaryCount) as unknown as Item),
       ...endPages
     ];
 
@@ -92,11 +110,11 @@
     return normalized;
   }
 
-  $: items = usePagination();
+  $: items = usePagination(page, totalPages, boundaryCount, siblingCount);
 
   onMount(() => {
     // Ensure initial page is clamped and consumers can react if needed
-    const normalized = clampPage(page);
+    const normalized = clampPage(page, totalPages);
     if (normalized !== page) {
       page = normalized;
       dispatch('change', { page });
@@ -152,7 +170,7 @@
         <button
           class="ccl-pagination__control"
           on:click={() => goTo(page + 1)}
-          disabled={disabled || page === getPageCount()}
+          disabled={disabled || page === totalPages}
           aria-label="go to next page"
           type="button"
         >›</button>
@@ -162,8 +180,8 @@
       <li>
         <button
           class="ccl-pagination__control"
-          on:click={() => goTo(getPageCount())}
-          disabled={disabled || page === getPageCount()}
+          on:click={() => goTo(totalPages)}
+          disabled={disabled || page === totalPages}
           aria-label="go to last page"
           type="button"
         >»</button>

--- a/src/lib/PrismaticBookCard.svelte
+++ b/src/lib/PrismaticBookCard.svelte
@@ -7,11 +7,14 @@
     | '--grape-purple'
     | '--wrap-grey';
 
+  export type PrismaticBookCardSize = 'default' | 'large';
+
   export type PrismaticBookCardProps = {
     href?: string;
     linkLabel?: string;
     imageUrl?: string;
     imageAlt?: string;
+    size?: PrismaticBookCardSize;
     tone?: PrismaticBookCardTone;
   };
 </script>
@@ -24,6 +27,7 @@
   export let linkLabel: string = 'READ MORE';
   export let imageUrl: string | undefined = undefined;
   export let imageAlt: string = '';
+  export let size: PrismaticBookCardSize = 'default';
   export let tone: PrismaticBookCardTone = CCLVividColor.STRAWBERRY_PINK;
 
   const gradientEndColors: Record<string, ColorVar> = {
@@ -42,7 +46,7 @@
 </script>
 
 <article
-  class="prismatic-book-card"
+  class="prismatic-book-card size-{size}"
   style="--gradient-start: {gradientStart}; --gradient-end: {gradientEnd}; --accent-color: {accentColor};"
 >
   <div class="cover-slot" aria-label={imageUrl ? undefined : imageAlt || undefined}>
@@ -97,6 +101,13 @@
     letter-spacing: 0;
   }
 
+  .size-large {
+    gap: 24px;
+    width: min(100%, 370px);
+    height: 590px;
+    padding: 28px;
+  }
+
   .cover-slot {
     position: relative;
     display: flex;
@@ -107,6 +118,12 @@
     overflow: hidden;
     border-radius: 18px;
     background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+  }
+
+  .size-large .cover-slot {
+    height: auto;
+    aspect-ratio: 156 / 221;
+    border-radius: 22px;
   }
 
   .cover-image,
@@ -140,6 +157,11 @@
     overflow-wrap: anywhere;
   }
 
+  .size-large .link,
+  .size-large .link-label {
+    font-size: 14px;
+  }
+
   .link-icon {
     display: block;
     flex: 0 0 16px;
@@ -165,6 +187,10 @@
     .prismatic-book-card {
       height: auto;
       min-height: 500px;
+    }
+
+    .size-large {
+      min-height: 590px;
     }
 
     .cover-slot {

--- a/src/lib/PrismaticSiteFooter.svelte
+++ b/src/lib/PrismaticSiteFooter.svelte
@@ -12,6 +12,8 @@
     href: string;
   };
 
+  export type PrismaticSiteFooterDensity = 'default' | 'compact' | 'studio';
+
   export type PrismaticSiteFooterProps = {
     brand?: string;
     brandHref?: string;
@@ -21,6 +23,9 @@
     links?: PrismaticSiteFooterLink[];
     copyright?: string;
     ariaLabel?: string;
+    density?: PrismaticSiteFooterDensity;
+    studioGradientStart?: PrismaticSiteFooterTone;
+    studioGradientLast?: PrismaticSiteFooterTone;
     tone?: PrismaticSiteFooterTone;
   };
 </script>
@@ -34,6 +39,20 @@
   ];
 
   const year = new Date().getFullYear();
+  const darkTextTones: PrismaticSiteFooterTone[] = [
+    CCLVividColor.STRAWBERRY_PINK,
+    CCLVividColor.PINEAPPLE_YELLOW,
+    CCLVividColor.SODA_BLUE,
+    CCLVividColor.MELON_GREEN
+  ];
+  const darkTextColor =
+    'color-mix(in srgb, var(--palette-grape-900) 70%, black)';
+
+  function getTextColor(tone: PrismaticSiteFooterTone | undefined): string {
+    return tone && darkTextTones.includes(tone)
+      ? darkTextColor
+      : 'var(--color-surface-glass)';
+  }
 
   export let brand: string = 'CANDY CHUPS Lab.';
   export let brandHref: string | undefined = undefined;
@@ -43,6 +62,9 @@
   export let links: PrismaticSiteFooterLink[] = defaultLinks;
   export let copyright: string = `Copyright © ${year} CANDY CHUPS Lab. All Rights Reserved.`;
   export let ariaLabel: string = 'フッターナビゲーション';
+  export let density: PrismaticSiteFooterDensity = 'default';
+  export let studioGradientStart: PrismaticSiteFooterTone | undefined = undefined;
+  export let studioGradientLast: PrismaticSiteFooterTone | undefined = undefined;
   export let tone: PrismaticSiteFooterTone = CCLVividColor.STRAWBERRY_PINK;
 
   function toCssUrl(value: string): string {
@@ -58,11 +80,21 @@
   }
 
   $: accentColor = `var(${tone})`;
+  $: studioGradientStartColor = studioGradientStart
+    ? `var(${studioGradientStart})`
+    : 'var(--palette-grape-900)';
+  $: startTextColor = getTextColor(studioGradientStart);
+  $: lastTone = studioGradientLast ?? tone;
+  $: studioGradientLastColor = `var(${lastTone})`;
+  $: lastTextColor = getTextColor(lastTone);
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
   $: logoLabel = logoAlt?.trim() || brand;
 </script>
 
-<footer class="prismatic-site-footer" style="--accent-color: {accentColor};">
+<footer
+  class="prismatic-site-footer density-{density}"
+  style="--accent-color: {accentColor}; --studio-gradient-start: {studioGradientStartColor}; --studio-gradient-last: {studioGradientLastColor}; --footer-start-text-color: {startTextColor}; --footer-last-text-color: {lastTextColor};"
+>
   <div class="footer-main">
     {#if brandHref}
       <a class="brand" href={brandHref}>
@@ -110,27 +142,43 @@
 
 <style>
   .prismatic-site-footer {
+    --footer-gap: 32px;
+    --footer-min-height: 180px;
+    --footer-padding: 40px 48px 32px;
+
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    gap: 32px;
+    gap: var(--footer-gap);
     width: min(100%, 1300px);
-    min-height: 180px;
+    min-height: var(--footer-min-height);
     box-sizing: border-box;
-    padding: 40px 48px 32px;
-    border: 1.5px solid color-mix(in srgb, var(--accent-color) 52%, transparent);
+    padding: var(--footer-padding);
+    border: 1.5px solid color-mix(in srgb, var(--accent-color) 64%, var(--palette-grape-900));
     border-radius: 34px;
     background: linear-gradient(
       112deg,
-      color-mix(in srgb, var(--accent-color) 78%, var(--color-surface-glass)) 0%,
-      color-mix(in srgb, var(--accent-color) 42%, var(--color-surface-glass)) 58%,
-      color-mix(in srgb, var(--accent-color) 18%, var(--color-surface-glass)) 100%
+      var(--studio-gradient-start) 0%,
+      color-mix(in srgb, var(--studio-gradient-start) 68%, var(--studio-gradient-last)) 54%,
+      var(--studio-gradient-last) 100%
     );
     box-shadow: 0 16px 20px color-mix(in srgb, var(--palette-grape-900) 18%, transparent);
-    color: var(--palette-grape-900);
+    color: var(--footer-start-text-color);
     font-family: Inter, sans-serif;
     line-height: normal;
     letter-spacing: 0;
+  }
+
+  .density-compact {
+    --footer-gap: 20px;
+    --footer-min-height: 132px;
+    --footer-padding: 28px 36px 24px;
+  }
+
+  .density-studio {
+    --footer-gap: 40px;
+    --footer-min-height: 240px;
+    --footer-padding: 52px 56px 40px;
   }
 
   .footer-main {
@@ -154,12 +202,13 @@
     display: block;
     width: min(300px, 48vw);
     height: var(--logo-height);
-    background: var(--color-surface-glass);
+    background: currentColor;
     -webkit-mask: var(--logo-image) left center / contain no-repeat;
     mask: var(--logo-image) left center / contain no-repeat;
   }
 
   nav {
+    color: var(--footer-last-text-color);
     min-width: 0;
   }
 
@@ -198,15 +247,32 @@
 
   @media (max-width: 640px) {
     .prismatic-site-footer {
-      gap: 28px;
-      min-height: 220px;
-      padding: 32px 28px 28px;
+      --footer-gap: 28px;
+      --footer-min-height: 220px;
+      --footer-padding: 32px 28px 28px;
+
       border-radius: 28px;
+    }
+
+    .density-compact {
+      --footer-gap: 20px;
+      --footer-min-height: 132px;
+      --footer-padding: 28px 28px 24px;
+    }
+
+    .density-studio {
+      --footer-gap: 40px;
+      --footer-min-height: 240px;
+      --footer-padding: 52px 28px 40px;
     }
 
     .footer-main {
       flex-direction: column;
       gap: 24px;
+    }
+
+    nav {
+      color: var(--footer-start-text-color);
     }
 
     ul {

--- a/src/lib/PrismaticSiteHeader.svelte
+++ b/src/lib/PrismaticSiteHeader.svelte
@@ -13,12 +13,18 @@
     active?: boolean;
   };
 
+  export type PrismaticSiteHeaderLogoFit = 'contain' | 'cover';
+
   export type PrismaticSiteHeaderProps = {
     brand?: string;
     brandHref?: string;
     logoUrl?: string;
     logoAlt?: string;
     logoHeight?: string;
+    logoWidth?: string;
+    logoFit?: PrismaticSiteHeaderLogoFit;
+    padding?: string;
+    minHeight?: string;
     navigation?: PrismaticSiteHeaderItem[];
     ariaLabel?: string;
     tone?: PrismaticSiteHeaderTone;
@@ -41,6 +47,10 @@
   export let logoUrl: string | undefined = undefined;
   export let logoAlt: string | undefined = undefined;
   export let logoHeight: string = '40px';
+  export let logoWidth: string = 'min(260px, 40vw)';
+  export let logoFit: PrismaticSiteHeaderLogoFit = 'contain';
+  export let padding: string | undefined = undefined;
+  export let minHeight: string | undefined = undefined;
   export let navigation: PrismaticSiteHeaderItem[] = defaultNavigation;
   export let ariaLabel: string = 'メインナビゲーション';
   export let tone: PrismaticSiteHeaderTone = CCLVividColor.STRAWBERRY_PINK;
@@ -60,11 +70,18 @@
   }
 
   $: accentColor = `var(${tone})`;
+  $: headerPadding = padding ?? '24px 35px';
+  $: headerMobilePadding = padding ?? '22px 28px';
+  $: headerSmallPadding = padding ?? '20px 22px';
+  $: headerMinHeight = minHeight ?? '104px';
   $: logoImage = logoUrl ? toCssUrl(logoUrl) : 'none';
   $: logoLabel = logoAlt?.trim() || brand;
 </script>
 
-<header class="prismatic-site-header" style="--accent-color: {accentColor};">
+<header
+  class="prismatic-site-header"
+  style="--accent-color: {accentColor}; --header-padding: {headerPadding}; --header-mobile-padding: {headerMobilePadding}; --header-small-padding: {headerSmallPadding}; --header-min-height: {headerMinHeight};"
+>
   {#if brandHref}
     <svelte:element this={brandLinkElement} class="brand" href={brandHref}>
       {#if logoUrl}
@@ -73,10 +90,10 @@
           role="img"
           aria-label={logoLabel}
           data-logo-url={logoUrl}
-          style="--logo-height: {logoHeight}; --logo-image: {logoImage};"
+          style="--logo-height: {logoHeight}; --logo-width: {logoWidth}; --logo-fit: {logoFit}; --logo-image: {logoImage};"
         ></span>
       {:else}
-        {brand}
+        <slot name="logo">{brand}</slot>
       {/if}
     </svelte:element>
   {:else}
@@ -87,10 +104,10 @@
           role="img"
           aria-label={logoLabel}
           data-logo-url={logoUrl}
-          style="--logo-height: {logoHeight}; --logo-image: {logoImage};"
+          style="--logo-height: {logoHeight}; --logo-width: {logoWidth}; --logo-fit: {logoFit}; --logo-image: {logoImage};"
         ></span>
       {:else}
-        {brand}
+        <slot name="logo">{brand}</slot>
       {/if}
     </span>
   {/if}
@@ -119,9 +136,9 @@
     justify-content: space-between;
     gap: 32px;
     width: min(100%, 1300px);
-    min-height: 104px;
+    min-height: var(--header-min-height);
     box-sizing: border-box;
-    padding: 24px 35px;
+    padding: var(--header-padding);
     border: 1.5px solid color-mix(in srgb, var(--accent-color) 42%, transparent);
     border-radius: 34px;
     background: color-mix(in srgb, var(--color-surface-glass) 78%, transparent);
@@ -144,12 +161,12 @@
 
   .brand-logo {
     display: block;
-    width: min(260px, 40vw);
-    max-width: min(260px, 40vw);
+    width: var(--logo-width);
+    max-width: min(100%, 48vw);
     height: var(--logo-height);
     background: var(--accent-color);
-    -webkit-mask: var(--logo-image) left center / contain no-repeat;
-    mask: var(--logo-image) left center / contain no-repeat;
+    -webkit-mask: var(--logo-image) left center / var(--logo-fit) no-repeat;
+    mask: var(--logo-image) left center / var(--logo-fit) no-repeat;
   }
 
   nav {
@@ -209,8 +226,8 @@
       flex-direction: column;
       align-items: flex-start;
       gap: 12px;
-      min-height: 104px;
-      padding: 22px 28px;
+      min-height: var(--header-min-height);
+      padding: var(--header-mobile-padding);
     }
 
     nav {
@@ -228,7 +245,7 @@
 
   @media (max-width: 480px) {
     .prismatic-site-header {
-      padding: 20px 22px;
+      padding: var(--header-small-padding);
       border-radius: 28px;
     }
 

--- a/src/lib/PrismaticStoryCard.svelte
+++ b/src/lib/PrismaticStoryCard.svelte
@@ -13,6 +13,7 @@
     label?: string;
     href?: string;
     linkLabel?: string;
+    showLink?: boolean;
     imageUrl?: string;
     imageAlt?: string;
     squareImage?: boolean;
@@ -34,6 +35,7 @@
   export let label: string | undefined = undefined;
   export let href: string | undefined = undefined;
   export let linkLabel: string = 'Read more';
+  export let showLink: boolean = true;
   export let imageUrl: string | undefined = undefined;
   export let imageAlt: string = '';
   export let squareImage: boolean = false;
@@ -101,7 +103,7 @@
 
     <h3 class="title">{title}</h3>
 
-    {#if href}
+    {#if href && showLink}
       <svelte:element
         this={linkElement}
         class="link"

--- a/src/lib/PrismaticWorkCard.svelte
+++ b/src/lib/PrismaticWorkCard.svelte
@@ -9,6 +9,7 @@
 
   export type PrismaticWorkCardProps = {
     title?: string;
+    description?: string;
     href?: string;
     linkLabel?: string;
     imageUrl?: string;
@@ -22,6 +23,7 @@
   import type { ColorVar } from './const/config';
 
   export let title: string = 'CCL Component Kit';
+  export let description: string | undefined = undefined;
   export let href: string | undefined = undefined;
   export let linkLabel: string = 'VIEW PROJECT';
   export let imageUrl: string | undefined = undefined;
@@ -57,7 +59,13 @@
   </div>
 
   <div class="body">
-    <h3 class="title">{title}</h3>
+    <div class="copy">
+      <h3 class="title">{title}</h3>
+
+      {#if description}
+        <p class="description">{description}</p>
+      {/if}
+    </div>
 
     {#if href}
       <svelte:element
@@ -140,6 +148,14 @@
     min-width: 0;
   }
 
+  .copy {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
   .title {
     margin: 0;
     max-width: 100%;
@@ -147,6 +163,17 @@
     font-size: 26px;
     font-weight: 700;
     line-height: normal;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .description {
+    margin: 0;
+    max-width: 100%;
+    color: color-mix(in srgb, var(--palette-grape-900) 34%, var(--palette-wrap-800));
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.75;
     overflow-wrap: anywhere;
     word-break: normal;
   }

--- a/src/stories/AllColors/AllColorsPrismaticSiteFooterWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticSiteFooterWrapper.svelte
@@ -11,6 +11,7 @@
       <h2>{name}</h2>
       <PrismaticSiteFooter
         {tone}
+        density="studio"
         brandHref="/"
         logoUrl="candy-chups-lab.svg"
         logoAlt="CANDY CHUPS Lab."

--- a/src/stories/AllColors/AllColorsPrismaticWorkCardWrapper.svelte
+++ b/src/stories/AllColors/AllColorsPrismaticWorkCardWrapper.svelte
@@ -11,7 +11,12 @@
     <div class="work-card-grid">
       {#each vividColors as [name, tone] (name)}
         <div class="color-sample">
-          <PrismaticWorkCard title={`${name} の制作実績`} linkLabel="VIEW PROJECT" {tone} />
+          <PrismaticWorkCard
+            title={`${name}の制作実績`}
+            description="各toneで概要文の折り返しと余白を確認するためのサンプルです。"
+            linkLabel="VIEW PROJECT"
+            {tone}
+          />
         </div>
       {/each}
     </div>

--- a/src/stories/Pagination.stories.ts
+++ b/src/stories/Pagination.stories.ts
@@ -61,13 +61,13 @@ export const Default: Story = {
     await step('次へをクリックすると、アクティブページが 2 になること', async () => {
       const next = await canvas.getByRole('button', { name: /go to next page/i });
       await userEvent.click(next);
-      const page2 = await canvas.getByRole('button', { name: /go to page 2/i });
+      const page2 = await canvas.findByRole('button', { name: /go to page 2/i });
       await expect(page2).toHaveAttribute('aria-current', 'page');
     });
     await step('最後へをクリックすると、アクティブページが 最終 になること', async () => {
       const last = await canvas.getByRole('button', { name: /go to last page/i });
       await userEvent.click(last);
-      const lastPage = await canvas.getByRole('button', { name: /go to page 12/i });
+      const lastPage = await canvas.findByRole('button', { name: /go to page 12/i });
       await expect(lastPage).toHaveAttribute('aria-current', 'page');
     });
   }
@@ -89,13 +89,13 @@ export const ManyPages: Story = {
     await step('前へをクリックすると、アクティブページが 9 になること', async () => {
       const prev = await canvas.getByRole('button', { name: /go to previous page/i });
       await userEvent.click(prev);
-      const page9 = await canvas.getByRole('button', { name: /go to page 9/i });
+      const page9 = await canvas.findByRole('button', { name: /go to page 9/i });
       await expect(page9).toHaveAttribute('aria-current', 'page');
     });
     await step('最後へをクリックすると、アクティブページが 最終 になること', async () => {
       const last = await canvas.getByRole('button', { name: /go to last page/i });
       await userEvent.click(last);
-      const page50 = await canvas.getByRole('button', { name: /go to page 50/i });
+      const page50 = await canvas.findByRole('button', { name: /go to page 50/i });
       await expect(page50).toHaveAttribute('aria-current', 'page');
     });
   }
@@ -117,13 +117,13 @@ export const MinimalControls: Story = {
     await step('次へをクリックすると、アクティブページが 4 になること', async () => {
       const next = await canvas.getByRole('button', { name: /go to next page/i });
       await userEvent.click(next);
-      const page4 = await canvas.getByRole('button', { name: /go to page 4/i });
+      const page4 = await canvas.findByRole('button', { name: /go to page 4/i });
       await expect(page4).toHaveAttribute('aria-current', 'page');
     });
     await step('前へをクリックすると、アクティブページが 3 に戻ること', async () => {
       const prev = await canvas.getByRole('button', { name: /go to previous page/i });
       await userEvent.click(prev);
-      const page3 = await canvas.getByRole('button', { name: /go to page 3/i });
+      const page3 = await canvas.findByRole('button', { name: /go to page 3/i });
       await expect(page3).toHaveAttribute('aria-current', 'page');
     });
   }

--- a/src/stories/PrismaticBookCard.stories.ts
+++ b/src/stories/PrismaticBookCard.stories.ts
@@ -26,6 +26,7 @@ const meta = {
     linkLabel: { control: { type: 'text' } },
     imageUrl: { control: { type: 'text' } },
     imageAlt: { control: { type: 'text' } },
+    size: { control: { type: 'select' }, options: ['default', 'large'] },
     tone: {
       control: { type: 'select' },
       options: toneOptions
@@ -67,6 +68,43 @@ export const WithImage: Story = {
 
     await step('表紙画像にalt属性が設定されていること', async () => {
       await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'PrismaticBookCardの書影');
+    });
+  }
+};
+
+export const Large: Story = {
+  args: {
+    href: 'https://example.com',
+    linkLabel: 'READ MORE',
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'largeサイズのPrismaticBookCard表紙',
+    size: 'large',
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('largeサイズをStorybookで選択できること', async () => {
+      await expect(args.size).toBe('large');
+    });
+
+    await step('largeサイズでもリンクと画像が表示されること', async () => {
+      await expect(canvas.getByRole('img')).toHaveAttribute(
+        'alt',
+        'largeサイズのPrismaticBookCard表紙'
+      );
+      await expect(canvas.getByRole('link', { name: 'READ MORE' })).toHaveAttribute(
+        'href',
+        'https://example.com'
+      );
+    });
+
+    await step('幅が変わってもlarge表紙の比率が維持されること', async () => {
+      const cover = canvasElement.querySelector('.cover-slot');
+
+      await expect(cover).not.toBeNull();
+      const { width, height } = (cover as HTMLElement).getBoundingClientRect();
+      await expect(width / height).toBeCloseTo(156 / 221, 2);
     });
   }
 };

--- a/src/stories/PrismaticSiteFooter.stories.ts
+++ b/src/stories/PrismaticSiteFooter.stories.ts
@@ -23,6 +23,9 @@ const meta = {
     links: { control: { type: 'object' } },
     copyright: { control: { type: 'text' } },
     ariaLabel: { control: { type: 'text' } },
+    density: { control: { type: 'select' }, options: ['default', 'compact', 'studio'] },
+    studioGradientStart: { control: { type: 'select' }, options: toneOptions },
+    studioGradientLast: { control: { type: 'select' }, options: toneOptions },
     tone: {
       control: { type: 'select' },
       options: toneOptions
@@ -97,6 +100,118 @@ export const CustomContent: Story = {
   }
 };
 
+export const StudioDensity: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    brandHref: '/',
+    links: [
+      { label: 'WORKS', href: '#works' },
+      { label: 'BOOKS', href: '#books' },
+      { label: 'CONTACT', href: '#contact' }
+    ],
+    copyright: '© 2026 CANDY CHUPS Lab.',
+    density: 'studio',
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('studio密度を指定できること', async () => {
+      await expect(args.density).toBe('studio');
+    });
+
+    await step('studioデザインでもリンクとコピーライトが表示されること', async () => {
+      await expect(canvas.getByRole('link', { name: 'WORKS' })).toHaveAttribute(
+        'href',
+        '#works'
+      );
+      await expect(canvas.getByText('© 2026 CANDY CHUPS Lab.')).toBeInTheDocument();
+    });
+  }
+};
+
+export const StudioCustomGradient: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    brandHref: '/',
+    links: [
+      { label: 'WORKS', href: '#works' },
+      { label: 'BOOKS', href: '#books' },
+      { label: 'CONTACT', href: '#contact' }
+    ],
+    copyright: '© 2026 CANDY CHUPS Lab.',
+    density: 'studio',
+    studioGradientStart: CCLVividColor.GRAPE_PURPLE,
+    studioGradientLast: CCLVividColor.PINEAPPLE_YELLOW,
+    tone: CCLVividColor.GRAPE_PURPLE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('studioグラデーション色を指定できること', async () => {
+      await expect(args.studioGradientStart).toBe(CCLVividColor.GRAPE_PURPLE);
+      await expect(args.studioGradientLast).toBe(CCLVividColor.PINEAPPLE_YELLOW);
+    });
+
+    await step('カスタムグラデーションでも主要情報が表示されること', async () => {
+      await expect(canvas.getByRole('link', { name: 'WORKS' })).toHaveAttribute(
+        'href',
+        '#works'
+      );
+      await expect(canvas.getByText('© 2026 CANDY CHUPS Lab.')).toBeInTheDocument();
+    });
+  }
+};
+
+export const CompactDensity: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    links: [{ label: 'CONTACT', href: '#contact' }],
+    density: 'compact',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('compact密度を指定できること', async () => {
+      await expect(args.density).toBe('compact');
+    });
+
+    await step('compact密度でも主要情報が表示されること', async () => {
+      await expect(canvas.getByText('CANDY CHUPS Lab.')).toBeInTheDocument();
+      await expect(canvas.getByRole('link', { name: 'CONTACT' })).toHaveAttribute(
+        'href',
+        '#contact'
+      );
+    });
+  }
+};
+
+export const MobileCompactDensity: Story = {
+  args: {
+    brand: 'CANDY CHUPS Lab.',
+    links: [{ label: 'CONTACT', href: '#contact' }],
+    density: 'compact',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1'
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('モバイル向けcompact表示でも主要情報が表示されること', async () => {
+      await expect(canvas.getByText('CANDY CHUPS Lab.')).toBeInTheDocument();
+      await expect(canvas.getByRole('link', { name: 'CONTACT' })).toHaveAttribute(
+        'href',
+        '#contact'
+      );
+    });
+  }
+};
+
 export const MixedWithFooter: Story = {
   render: () => ({ Component: PrismaticSiteFooterMixedWrapper }),
   args: {},
@@ -118,7 +233,7 @@ export const AllColors: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step('すべてのtone名が表示されていること', async () => {
+    await step('studioのカラーバリエーションが表示されていること', async () => {
       for (const name of Object.keys(CCLVividColor)) {
         await expect(canvas.getByRole('heading', { name })).toBeInTheDocument();
       }

--- a/src/stories/PrismaticSiteHeader.stories.ts
+++ b/src/stories/PrismaticSiteHeader.stories.ts
@@ -3,6 +3,7 @@ import { expect, within } from '@storybook/test';
 import PrismaticSiteHeader from '$lib/PrismaticSiteHeader.svelte';
 import { CCLVividColor } from '$lib/const/config';
 import AllColorsPrismaticSiteHeaderWrapper from './AllColors/AllColorsPrismaticSiteHeaderWrapper.svelte';
+import PrismaticSiteHeaderLogoSlotWrapper from './PrismaticSiteHeaderLogoSlotWrapper.svelte';
 import PrismaticSiteHeaderMixedWrapper from './PrismaticSiteHeaderMixedWrapper.svelte';
 
 const toneOptions = [
@@ -27,6 +28,10 @@ const meta = {
     logoUrl: { control: { type: 'text' } },
     logoAlt: { control: { type: 'text' } },
     logoHeight: { control: { type: 'text' } },
+    logoWidth: { control: { type: 'text' } },
+    logoFit: { control: { type: 'select' }, options: ['contain', 'cover'] },
+    padding: { control: { type: 'text' } },
+    minHeight: { control: { type: 'text' } },
     navigation: { control: { type: 'object' } },
     ariaLabel: { control: { type: 'text' } },
     tone: {
@@ -86,6 +91,48 @@ export const WithLogo: Story = {
         'href',
         '/'
       );
+    });
+  }
+};
+
+export const CompactLogoLayout: Story = {
+  args: {
+    brandHref: '/',
+    logoUrl: 'candy-chups-lab.svg',
+    logoAlt: 'CANDY CHUPS Lab.',
+    logoHeight: '48px',
+    logoWidth: '180px',
+    logoFit: 'contain',
+    padding: '18px 28px',
+    minHeight: '84px',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('ロゴ幅とヘッダー密度を指定できること', async () => {
+      const logo = canvas.getByRole('img', { name: 'CANDY CHUPS Lab.' });
+      await expect(logo.style.getPropertyValue('--logo-width')).toBe('180px');
+      await expect(logo.style.getPropertyValue('--logo-fit')).toBe('contain');
+    });
+  }
+};
+
+export const WithLogoSlot: Story = {
+  render: () => ({ Component: PrismaticSiteHeaderLogoSlotWrapper }),
+  args: {},
+  parameters: {
+    docs: {
+      source: {
+        code: null
+      }
+    }
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('ロゴslotの内容がブランドリンクとして表示されること', async () => {
+      await expect(canvas.getByRole('link', { name: 'CCL Studio' })).toHaveAttribute('href', '/');
     });
   }
 };

--- a/src/stories/PrismaticSiteHeaderLogoSlotWrapper.svelte
+++ b/src/stories/PrismaticSiteHeaderLogoSlotWrapper.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import PrismaticSiteHeader from '../lib/PrismaticSiteHeader.svelte';
+  import { CCLVividColor } from '../lib/const/config';
+</script>
+
+<div class="canvas">
+  <PrismaticSiteHeader
+    brandHref="/"
+    padding="18px 28px"
+    minHeight="84px"
+    tone={CCLVividColor.SODA_BLUE}
+  >
+    <span slot="logo" class="custom-logo">CCL Studio</span>
+  </PrismaticSiteHeader>
+</div>
+
+<style>
+  .canvas {
+    padding: 24px;
+  }
+
+  .custom-logo {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    color: inherit;
+    font-size: 20px;
+    font-weight: 800;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/src/stories/PrismaticStoryCard.stories.ts
+++ b/src/stories/PrismaticStoryCard.stories.ts
@@ -35,6 +35,9 @@ const meta = {
     linkLabel: {
       control: { type: 'text' }
     },
+    showLink: {
+      control: { type: 'boolean' }
+    },
     imageUrl: {
       control: { type: 'text' }
     },
@@ -140,6 +143,37 @@ export const WithImage: Story = {
 
     await step('タイトルが表示されていること', async () => {
       await expect(canvas.getByText('画像を差し込んだStoryCard')).toBeInTheDocument();
+    });
+  }
+};
+
+export const WithoutInlineLink: Story = {
+  args: {
+    title: 'Selected Story Feature',
+    label: 'FEATURE',
+    href: 'https://example.com',
+    linkLabel: 'READ MORE',
+    showLink: false,
+    imageUrl: 'thumbnail.png',
+    imageAlt: 'リンク非表示のStoryCardサムネイル',
+    size: 'featured',
+    tone: CCLVividColor.PINEAPPLE_YELLOW
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('タイトルと画像が中心の表示になること', async () => {
+      await expect(
+        canvas.getByRole('heading', { name: 'Selected Story Feature', level: 3 })
+      ).toBeInTheDocument();
+      await expect(canvas.getByRole('img')).toHaveAttribute(
+        'alt',
+        'リンク非表示のStoryCardサムネイル'
+      );
+    });
+
+    await step('showLinkがfalseのときREAD MOREリンクが表示されないこと', async () => {
+      await expect(canvas.queryByRole('link', { name: 'READ MORE' })).not.toBeInTheDocument();
     });
   }
 };

--- a/src/stories/PrismaticWorkCard.stories.ts
+++ b/src/stories/PrismaticWorkCard.stories.ts
@@ -25,6 +25,9 @@ const meta = {
     title: {
       control: { type: 'text' }
     },
+    description: {
+      control: { type: 'text' }
+    },
     href: {
       control: { type: 'text' }
     },
@@ -63,11 +66,60 @@ export const Default: Story = {
       ).toBeInTheDocument();
     });
 
-    await step('CTAリンクが表示されていること', async () => {
+    await step('概要文なしでもCTAリンクが表示されていること', async () => {
       await expect(canvas.getByRole('link', { name: 'VIEW PROJECT' })).toHaveAttribute(
         'href',
         'https://example.com'
       );
+    });
+  }
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: 'CCL Component Kit',
+    description:
+      'Svelte向けのUIコンポーネントライブラリ。サイトやアプリで使う共通UIを、Prismatic Designの色彩でまとめます。',
+    href: 'https://www.npmjs.com/package/cclkit4svelte',
+    linkLabel: 'VIEW PROJECT',
+    tone: CCLVividColor.SODA_BLUE
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('概要文がタイトルとリンクの間に表示されていること', async () => {
+      await expect(
+        canvas.getByText(
+          'Svelte向けのUIコンポーネントライブラリ。サイトやアプリで使う共通UIを、Prismatic Designの色彩でまとめます。'
+        )
+      ).toBeInTheDocument();
+    });
+
+    await step('概要文つきでもCTAリンクが表示されていること', async () => {
+      await expect(canvas.getByRole('link', { name: 'VIEW PROJECT' })).toHaveAttribute(
+        'href',
+        'https://www.npmjs.com/package/cclkit4svelte'
+      );
+    });
+  }
+};
+
+export const LongDescription: Story = {
+  args: {
+    title: 'Selected Works Showcase',
+    description:
+      'Selected Worksで複数行の紹介文を表示する想定です。長めの説明や区切りのない英数字MixedContentForResponsiveLayoutVerificationが入っても、カード幅からはみ出さず読みやすく折り返されます。',
+    href: 'https://example.com',
+    linkLabel: 'VIEW PROJECT',
+    tone: CCLVividColor.MELON_GREEN
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('長い概要文が表示されていること', async () => {
+      await expect(
+        canvas.getByText(/Selected Worksで複数行の紹介文を表示する想定です/)
+      ).toBeInTheDocument();
     });
   }
 };
@@ -100,6 +152,7 @@ export const Japanese: Story = {
 export const WithImage: Story = {
   args: {
     title: '画像を差し込んだWorkCard',
+    description: '画像付きの制作実績として、プロジェクトの概要を短く添えます。',
     href: 'https://example.com',
     linkLabel: 'VIEW PROJECT',
     imageUrl: 'thumbnail.png',
@@ -113,8 +166,10 @@ export const WithImage: Story = {
       await expect(canvas.getByRole('img')).toHaveAttribute('alt', 'WorkCardのサムネイル');
     });
 
-    await step('タイトルが表示されていること', async () => {
-      await expect(canvas.getByText('画像を差し込んだWorkCard')).toBeInTheDocument();
+    await step('画像つきでも概要文が表示されていること', async () => {
+      await expect(
+        canvas.getByText('画像付きの制作実績として、プロジェクトの概要を短く添えます。')
+      ).toBeInTheDocument();
     });
   }
 };
@@ -122,6 +177,7 @@ export const WithImage: Story = {
 export const WithoutLink: Story = {
   args: {
     title: 'リンクなしの制作実績',
+    description: '公開前のプロジェクトでも、概要文だけを先に表示できます。',
     linkLabel: 'COMING SOON',
     tone: CCLVividColor.PINEAPPLE_YELLOW
   },
@@ -158,7 +214,7 @@ export const MixedWithServiceCard: Story = {
     });
 
     await step('既存ServiceCardとの差分を確認できること', async () => {
-      await expect(canvas.getByText('Prismatic Design の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('Prismatic Designの制作実績')).toBeInTheDocument();
       await expect(canvas.getByText('既存サービスカード')).toBeInTheDocument();
     });
   }
@@ -189,12 +245,12 @@ export const AllColors: Story = {
     });
 
     await step('各tone名の制作実績が表示されていること', async () => {
-      await expect(canvas.getByText('STRAWBERRY_PINK の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('PINEAPPLE_YELLOW の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('SODA_BLUE の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('MELON_GREEN の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('GRAPE_PURPLE の制作実績')).toBeInTheDocument();
-      await expect(canvas.getByText('WRAP_GREY の制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('STRAWBERRY_PINKの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('PINEAPPLE_YELLOWの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('SODA_BLUEの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('MELON_GREENの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('GRAPE_PURPLEの制作実績')).toBeInTheDocument();
+      await expect(canvas.getByText('WRAP_GREYの制作実績')).toBeInTheDocument();
     });
   }
 };

--- a/src/stories/PrismaticWorkCardMixedWrapper.svelte
+++ b/src/stories/PrismaticWorkCardMixedWrapper.svelte
@@ -8,7 +8,8 @@
   <section class="sample">
     <h2>PrismaticWorkCard</h2>
     <PrismaticWorkCard
-      title="Prismatic Design の制作実績"
+      title="Prismatic Designの制作実績"
+      description="選択した制作実績の目的や内容を短く伝える概要文を表示します。"
       href="https://example.com"
       linkLabel="VIEW PROJECT"
       imageUrl="thumbnail.png"

--- a/src/stories/README.mdx
+++ b/src/stories/README.mdx
@@ -5,7 +5,7 @@ import { Meta } from '@storybook/blocks';
 # ccl-component-kit4svelte
 
 [![Release Storybook to GitHubPages](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/storybook-release.yaml)
-[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg?branch=main)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
+[![Publish Package to npmjs](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml/badge.svg)](https://github.com/reiji1020/ccl-component-kit4svelte/actions/workflows/publish-package.yaml)
 
 ![library_card](library_card.png)
 


### PR DESCRIPTION
## 概要

`4.0.1` のパッチリリースです。Prismaticコンポーネントの表示バリエーション拡充、Paginationの表示更新修正、リリースworkflowバッジの整合を含みます。

## リリース内容

- `PrismaticWorkCard` に任意の `description` を追加し、長文表示とStorybook例を拡充（#125, #127）
- `PrismaticSiteHeader`、`PrismaticStoryCard`、`PrismaticBookCard`、`PrismaticSiteFooter` の表示・設定バリエーションを追加（#126, #128）
- `siblingCount={0}` を含むPaginationで、ページ移動後に表示項目を再計算するよう修正（#129, #131）
- READMEとStorybook READMEのnpm公開バッジをrelease起点のworkflow状態と一致するよう修正（#130, #132）
- `package.json` と `docs/CHANGELOG.md` を `4.0.1` に更新

## 破壊的変更

なし

## 確認事項

- [ ] CIが成功していること
- [x] `pnpm check` が成功していること（0 errors、既存の11 warnings）
- [x] `pnpm run package` が成功していること
- [x] `pnpm build-storybook` が成功していること
- [x] 公開APIとバージョン番号が意図どおりであること
- [x] `package.json` と `docs/CHANGELOG.md` がリリースバージョンに合わせて更新されていること