### PR TITLE
Node.js 22 LTSへ更新する

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '22.23.1'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 

--- a/.github/workflows/storybook-release.yaml
+++ b/.github/workflows/storybook-release.yaml
@@ -22,10 +22,10 @@ jobs:
         with:
           version: 10.28.2
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 22.23.1
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: '22.23.1'
           cache: pnpm
 
       - name: Install Node Dependencies

--- a/README.md
+++ b/README.md
@@ -45,18 +45,18 @@ pnpm install cclkit4svelte
 
 ## 本ライブラリの開発について
 
-コンポーネントライブラリの開発には、Node.jsのVersion20以降の環境が必要です。パッケージマネージャにはnpmを使用します。詳細なバージョンについては`package.json`に記載をしていますのでご確認ください。
+コンポーネントライブラリの開発には、Node.js 22.23.1以降の環境が必要です。パッケージマネージャにはpnpmを使用します。詳細なバージョンについては`package.json`に記載をしていますのでご確認ください。
 
 Node.jsのバージョン切り替えには[Volta](https://volta.sh/)をおすすめします。
 
 ```zsh
 volta install node
 # or
-volta install node@20
+volta install node@22.23.1
 
 node -v
 #任意のNodeのバージョンが表示されればOK
-v20.11.1
+v22.23.1
 ```
 
 また、本ライブラリの開発には`pnpm`の導入が必要です。`npm`や`yarn`では開発準備ができないためご注意ください。voltaを使用している場合、pnpmもvoltaを使用して導入することができます。
@@ -108,18 +108,18 @@ pnpm install cclkit4svelte
 
 ## About the development of this library
 
-The development of component libraries requires a Node.js environment with Version 20 or higher. Use pnpm as the package manager. Please check the `package.json` for detailed version information.
+The development of component libraries requires Node.js 22.23.1 or later. Use pnpm as the package manager. Please check `package.json` for detailed version information.
 
 We recommend [Volta](https://volta.sh/) for switching Node.js versions.
 
 ```zsh
 volta install node
 # or
-volta install node@20
+volta install node@22.23.1
 
 node -v
 #Once the desired Node version is displayed, it is OK.
-v20.11.1
+v22.23.1
 ```
 
 Also, you need to install `pnpm` to develop this library. Note that `npm` and `yarn` do not prepare you for development; if you are using volta, pnpm can also be installed using volta.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "description": "Component kit for CANDY CHUPS Lab.",
   "packageManager": "pnpm@10.28.2",
   "engines": {
-    "node": ">=20.11.1",
+    "node": ">=22.23.1",
     "pnpm": ">=10.28.2"
   },
   "scripts": {
@@ -89,7 +89,7 @@
     "svelte": "^5.0.0"
   },
   "volta": {
-    "node": "20.11.1",
+    "node": "22.23.1",
     "npm": "10.5.0"
   }
 }

--- a/src/stories/README.mdx
+++ b/src/stories/README.mdx
@@ -44,18 +44,18 @@ pnpm i cclkit4svelte
 
 ## 本ライブラリの開発について
 
-コンポーネントライブラリの開発には、Node.jsのVersion20以降の環境が必要です。パッケージマネージャにはnpmを使用します。詳細なバージョンについては`package.json`に記載をしていますのでご確認ください。
+コンポーネントライブラリの開発には、Node.js 22.23.1以降の環境が必要です。パッケージマネージャにはpnpmを使用します。詳細なバージョンについては`package.json`に記載をしていますのでご確認ください。
 
 Node.jsのバージョン切り替えには[Volta](https://volta.sh/)をおすすめします。
 
 ```zsh
 volta install node
 # or
-volta install node@20
+volta install node@22.23.1
 
 node -v
 #任意のNodeのバージョンが表示されればOK
-v20.11.1
+v22.23.1
 ```
 
 また、本ライブラリの開発には`pnpm`の導入が必要です。`npm`や`yarn`では開発準備ができないためご注意ください。voltaを使用している場合、pnpmもvoltaを使用して導入することができます。
@@ -107,18 +107,18 @@ pnpm i cclkit4svelte
 
 ## About the development of this library
 
-The development of component libraries requires a Node.js environment with Version 20 or higher. Use npm as the package manager. Please check the `package.json` for detailed version information.
+The development of component libraries requires Node.js 22.23.1 or later. Use pnpm as the package manager. Please check `package.json` for detailed version information.
 
 We recommend [Volta](https://volta.sh/) for switching Node.js versions.
 
 ```zsh
 volta install node
 # or
-volta install node@20
+volta install node@22.23.1
 
 node -v
 #Once the desired Node version is displayed, it is OK.
-v20.11.1
+v22.23.1
 ```
 
 Also, you need to install `pnpm` to develop this library. Note that `npm` and `yarn` do not prepare you for development; if you are using volta, pnpm can also be installed using volta.


### PR DESCRIPTION
## 概要

EOLとなったNode.js 20系からNode.js 22 LTSへ移行し、ローカル開発環境とGitHub Actionsのバージョン指定をNode.js 22.23.1へ統一しました。

## 変更内容

- `package.json`の`engines.node`を`>=22.23.1`、`volta.node`を`22.23.1`へ更新
- Storybook公開workflowとnpm publish workflowのNode.jsを`22.23.1`へ統一
- `README.md`とStorybook内READMEの日英開発環境案内をNode.js 22.23.1へ更新
- ドキュメント内のパッケージマネージャー表記を実態に合わせてpnpmへ統一

## 確認結果

- `node --version`: `v22.23.1`
- `pnpm install --frozen-lockfile`: 成功
- `pnpm check`: 成功（0 errors、既存warning 11件）
- `pnpm run package`: 成功
- `pnpm run build-storybook`: 成功

## 関連Issue

Closes #134